### PR TITLE
Add text as a hyperlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,33 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## 0.1.0 (2017-06-20)
-
+## [Unreleased] (2018-??-??)
 ### Added
-* **heading:** add headings to a document and modify their outline level
-* **paragraph:** add paragraphs to a document and modify their text content
-* **paragraph:** set page break before paragraph
-* **paragraph:** set horizontal alignment
-* **text-document:** create text documents and save them as flat XML ODF document
+- **paragraph:** Add hyperlinks to a paragraph (), closes [#5](https://github.com/connium/simple-odf/issues/5)
+
+## [0.2.0] (2018-01-12)
+### Added
+- **docs:** Add CHANGELOG
+- **docs:** Improve and extend README
+- **docs:** Add badges (dependencies, known vulnerabilities, version) to README
+- **list:** Add basic list support (add/insert/get/set/remove item)
+- **paragraph:** Overwrite text content
+- **style:** Get horizontal alignment
+- **test:** Add integration test
+
+### Changed
+- **general:** Export public API from / (no namespaces)
+- **paragraph:** Rename text related functions in paragraph
+- **heading:** Rename headline to heading
+
+## 0.1.0 (2018-01-08)
+### Added
+- **heading:** Add headings to a document and modify their outline level
+- **paragraph:** Add paragraphs to a document and modify their text content
+- **paragraph:** Set page break before paragraph
+- **paragraph:** Set horizontal alignment
+- **text-document:** Create text documents and save them as flat XML ODF document
+
+[Unreleased]: https://github.com/connium/simple-odf/compare/v0.2.0...HEAD
+[0.3.0]: https://github.com/connium/simple-odf/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/connium/simple-odf/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ const document = new simpleOdf.TextDocument();
 document.addHeadline("My First Document");
 
 const p1 = document.addParagraph("The quick, brown fox jumps over a lazy dog.");
-p1.appendTextContent("\nThe five boxing wizards jump quickly");
+p1.appendTextContent("\nThe five boxing wizards jump quickly\n\n");
+p1.appendHyperlink("Visit me", "http://example.org/");
 
 document.addHeadline("Credits", 2);
 

--- a/src/OdfAttributeName.ts
+++ b/src/OdfAttributeName.ts
@@ -5,6 +5,9 @@ export enum OdfAttributeName {
   StyleFamily = "style:family",
   StyleName = "style:name",
 
-  TextStyleName = "text:style-name",
   TextOutlineLevel = "text:outline-level",
+  TextStyleName = "text:style-name",
+
+  XlinkHref = "xlink:href",
+  XlinkType = "xlink:type",
 }

--- a/src/OdfElementName.ts
+++ b/src/OdfElementName.ts
@@ -8,6 +8,7 @@ export enum OdfElementName {
   StyleTextProperties = "style:text-properties",
   StyleParagraphProperties = "style:paragraph-properties",
 
+  TextHyperlink = "text:a",
   TextHeading = "text:h",
   TextLineBreak = "text:line-break",
   TextList = "text:list",

--- a/src/text/HyperLink.ts
+++ b/src/text/HyperLink.ts
@@ -1,0 +1,61 @@
+import { OdfAttributeName } from "../OdfAttributeName";
+import { OdfElementName } from "../OdfElementName";
+import { Text } from "./Text";
+
+/**
+ * This class represents a hyperlink in a paragraph.
+ *
+ * @since 0.3.0
+ */
+export class Hyperlink extends Text {
+  /**
+   * Creates a hyperlink
+   *
+   * @param {string} text The text content of the hyperlink
+   * @param {string} uri The URI of the hyperlink
+   * @since 0.3.0
+   */
+  public constructor(text: string, private uri: string) {
+    super(text);
+  }
+
+  /**
+   * Returns the URI of this hyperlink.
+   *
+   * @returns {string} The URI of this hyperlink
+   * @since 0.3.0
+   */
+  public getURI(): string {
+    return this.uri;
+  }
+
+  /**
+   * Sets the URI for this hyperlink.
+   *
+   * @param {string} uri The new URI of this hyperlink
+   * @since 0.3.0
+   */
+  public setURI(uri: string): void {
+    this.uri = uri;
+  }
+
+  /** @inheritDoc */
+  protected toXML(document: Document, parent: Element): void {
+    const text = this.getText();
+
+    if (text === undefined || text === "") {
+      return;
+    }
+
+    (document.firstChild as Element).setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+
+    const hyperlink = document.createElement(OdfElementName.TextHyperlink);
+    hyperlink.setAttribute(OdfAttributeName.XlinkType, "simple");
+    hyperlink.setAttribute(OdfAttributeName.XlinkHref, this.uri);
+
+    const textNode = document.createTextNode(text);
+    hyperlink.appendChild(textNode);
+
+    parent.appendChild(hyperlink);
+  }
+}

--- a/src/text/Text.ts
+++ b/src/text/Text.ts
@@ -1,0 +1,58 @@
+import { OdfElement } from "../OdfElement";
+import { OdfElementName } from "../OdfElementName";
+
+/**
+ * This class represents text in a paragraph.
+ *
+ * @since 0.3.0
+ */
+export class Text extends OdfElement {
+  /**
+   * Creates a text
+   *
+   * @param {string} text The text content
+   * @since 0.3.0
+   */
+  public constructor(private text: string) {
+    super();
+  }
+
+  /**
+   * Returns the text content.
+   *
+   * @returns {string} The text content
+   * @since 0.3.0
+   */
+  public getText(): string {
+    return this.text;
+  }
+
+  /**
+   * Sets the new text content.
+   *
+   * @param {string} text The new text content
+   * @since 0.3.0
+   */
+  public setText(text: string): void {
+    this.text = text;
+  }
+
+  /** @inheritDoc */
+  protected toXML(document: Document, parent: Element): void {
+    if (this.text === undefined || this.text === "") {
+      return;
+    }
+
+    const lines = this.text.split("\n");
+
+    for (let i = 0; i < lines.length; i++) {
+      if (i > 0) {
+        const lineBreak = document.createElement(OdfElementName.TextLineBreak);
+        parent.appendChild(lineBreak);
+      }
+
+      const textNode = document.createTextNode(lines[i]);
+      parent.appendChild(textNode);
+    }
+  }
+}

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -34,6 +34,10 @@ describe(TextDocument.name, () => {
     const heading30 = document.addHeading("Another chapter");
     heading30.setPageBreak();
 
+    const para2 = document.addParagraph("This is just an ");
+    para2.appendHyperlink("example", "http://example.org");
+    para2.appendText(".");
+
     await document.saveFlat(FILEPATH);
     done();
   });

--- a/test/text/Heading.spec.ts
+++ b/test/text/Heading.spec.ts
@@ -9,12 +9,18 @@ describe(Heading.name, () => {
     document = new TextDocument();
   });
 
+  it("add text namespace", () => {
+    document.addHeading();
+
+    const documentAsString = document.toString();
+    expect(documentAsString).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
+  });
+
   it("insert an empty heading with default level 1", () => {
     document.addHeading();
 
     const documentAsString = document.toString();
     expect(documentAsString).toMatch(/<text:h text:outline-level="1"\/>/);
-    expect(documentAsString).not.toMatch(/xmlns:text/);
   });
 
   it("insert a heading with given text and default level 1", () => {
@@ -22,7 +28,6 @@ describe(Heading.name, () => {
 
     const documentAsString = document.toString();
     expect(documentAsString).toMatch(/<text:h text:outline-level="1">heading<\/text:h>/);
-    expect(documentAsString).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
   });
 
   it("insert a heading with given text and given level", () => {

--- a/test/text/Paragraph.spec.ts
+++ b/test/text/Paragraph.spec.ts
@@ -1,6 +1,6 @@
+import { HorizontalAlignment } from "../../src/style/HorizontalAlignment";
 import { Paragraph } from "../../src/text/Paragraph";
 import { TextDocument } from "../../src/TextDocument";
-import { HorizontalAlignment } from "../../src/style/HorizontalAlignment";
 
 describe(Paragraph.name, () => {
   let document: TextDocument;
@@ -9,26 +9,34 @@ describe(Paragraph.name, () => {
     document = new TextDocument();
   });
 
+  it("add text namespace", () => {
+    document.addParagraph();
+
+    const documentAsString = document.toString();
+    expect(documentAsString).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
+  });
+
   it("insert an empty paragraph", () => {
     document.addParagraph();
 
     const documentAsString = document.toString();
     expect(documentAsString).toMatch(/<text:p\/>/);
-    expect(documentAsString).not.toMatch(/xmlns:text/);
   });
 
-  it("insert a paragraph with specified text and add text namespace", () => {
+  it("insert a paragraph with specified text", () => {
     document.addParagraph("some text");
 
     const documentAsString = document.toString();
     expect(documentAsString).toMatch(/<text:p>some text<\/text:p>/);
-    expect(documentAsString).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
   });
 
   it("return the text", () => {
     const paragraph = document.addParagraph("some text");
+    paragraph.appendText(" some\nmore   text");
+    paragraph.appendHyperlink(" link", "http://example.org/");
+    paragraph.appendText(" even more text");
 
-    expect(paragraph.getText()).toEqual("some text");
+    expect(paragraph.getText()).toEqual("some text some\nmore   text link even more text");
   });
 
   describe("#appendText", () => {
@@ -57,13 +65,12 @@ describe(Paragraph.name, () => {
     expect(documentAsString).toMatch(/<text:p>some other text<\/text:p>/);
   });
 
-  it("remove text from paragraph and not add text namespace", () => {
+  it("remove text from paragraph", () => {
     const paragraph = document.addParagraph("some text");
     paragraph.removeText();
 
     const documentAsString = document.toString();
     expect(documentAsString).toMatch(/<text:p\/>/);
-    expect(documentAsString).not.toMatch(/xmlns:text/);
   });
 
   it("replace newline with line break", () => {
@@ -71,6 +78,34 @@ describe(Paragraph.name, () => {
 
     const documentAsString = document.toString();
     expect(documentAsString).toMatch(/<text:p>some text<text:line-break\/>some more text<\/text:p>/);
+  });
+
+  describe("#appendHyperlink", () => {
+    it("add xlink namespace", () => {
+      const paragraph = document.addParagraph();
+      paragraph.appendHyperlink("some linked text", "http://example.org/");
+
+      const documentAsString = document.toString();
+      expect(documentAsString).toMatch(/xmlns:xlink="http:\/\/www.w3.org\/1999\/xlink"/);
+    });
+
+    it("append a linked text", () => {
+      const paragraph = document.addParagraph("some text");
+      paragraph.appendHyperlink(" some linked text", "http://example.org/");
+
+      const documentAsString = document.toString();
+      /* tslint:disable-next-line:max-line-length */
+      expect(documentAsString).toMatch(/<text:p>some text<text:a xlink:type="simple" xlink:href="http:\/\/example.org\/"> some linked text<\/text:a><\/text:p>/);
+    });
+
+    it("not create a hyperlink if text is empty", () => {
+      const paragraph = document.addParagraph("some text");
+      paragraph.appendHyperlink("", "http://example.org/");
+
+      const documentAsString = document.toString();
+      /* tslint:disable-next-line:max-line-length */
+      expect(documentAsString).toMatch(/<text:p>some text<\/text:p>/);
+    });
   });
 
   describe("style", () => {


### PR DESCRIPTION
paragraph: append hyperlink

Append a hyperlink to a paragraph. It is possible to edit the text and URI of the hyperlink. If the hyperlink is empty it will be omitted in the final document.

Changes to the internal handling of text content were necessary for the paragraph to make this possible. Text now is handled as `Text` elements instead of a single instance variable.

Added changelog for v0.2.0 as it was missing.

Fixes #5 