### PR TITLE
Rewrite the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **paragraph:** Add hyperlinks to a paragraph, closes [#5](https://github.com/connium/simple-odf/issues/5)
 
 ### Changed
-- **general:** Full rewrite of the public API
+- **general:** Full rewrite of the public API to use the terminology of the Open Document Format
 
 ## [0.2.0] (2018-01-12)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased] (2018-??-??)
 ### Added
-- **paragraph:** Add hyperlinks to a paragraph (), closes [#5](https://github.com/connium/simple-odf/issues/5)
+- **paragraph:** Add hyperlinks to a paragraph, closes [#5](https://github.com/connium/simple-odf/issues/5)
+
+### Changed
+- **general:** Full rewrite of the public API
 
 ## [0.2.0] (2018-01-12)
 ### Added

--- a/src/OdfElement.ts
+++ b/src/OdfElement.ts
@@ -14,17 +14,25 @@ export class OdfElement {
   }
 
   /**
-   * Appends a child element to this element.
+   * Appends the element as a child element to this element.
    *
    * @param {OdfElement} element The element to append
    * @since 0.1.0
    */
-  public appendElement(element: OdfElement): void {
+  public append(element: OdfElement): void {
     this.children.push(element);
   }
 
-  /** TODO */
-  protected insertElement(position: number, element: OdfElement): void {
+  /**
+   * Inserts the element at the specified position in the list of child elements.
+   *
+   * @param {number} position The index at which to insert the element (starting from 0).
+   * If greater than the number child elements, the element will appended at the end of the list.
+   * If negative, the element will be inserted as first element.
+   * @param {OdfElement} element The element to insert
+   * @since 0.2.0
+   */
+  protected insert(position: number, element: OdfElement): void {
     let index = position;
 
     if (position < 0) {
@@ -36,8 +44,15 @@ export class OdfElement {
     this.children.splice(index, 0, element);
   }
 
-  /** TODO */
-  protected getElement(position: number): OdfElement | undefined {
+  /**
+   * Returns the element at the specified position.
+   *
+   * @param {number} position The index of the requested the element (starting from 0).
+   * @returns {OdfElement | undefined} The element at the specified position
+   * or undefined if there is no element at the specified position
+   * @since 0.2.0
+   */
+  protected get(position: number): OdfElement | undefined {
     if (position < 0) {
       return undefined;
     }
@@ -48,25 +63,26 @@ export class OdfElement {
     return this.children[position];
   }
 
-  /** TODO */
-  protected getElements(): OdfElement[] {
+  /**
+   * Returns all child elements.
+   *
+   * @returns {OdfElement[]} A copy of the list of child elements
+   * @since 0.2.0
+   */
+  protected getAll(): OdfElement[] {
     return Array.from(this.children);
   }
 
-  /** TODO */
-  protected setElement(position: number, element: OdfElement): OdfElement | undefined {
-    const oldElement = this.getElement(position);
-
-    if (oldElement !== undefined) {
-      this.children[position] = element;
-    }
-
-    return oldElement;
-  }
-
-  /** TODO */
-  protected removeElement(position: number): OdfElement | undefined {
-    const oldElement = this.getElement(position);
+  /**
+   * Removes the child element from the specified position.
+   *
+   * @param {number} position The index of the element to remove (starting from 0).
+   * @returns {OdfElement | undefined} The removed child element
+   * or undefined if there is no element at the specified position
+   * @since 0.2.0
+   */
+  protected removeAt(position: number): OdfElement | undefined {
+    const oldElement = this.get(position);
 
     if (oldElement !== undefined) {
       this.children.splice(position, 1);
@@ -75,7 +91,12 @@ export class OdfElement {
     return oldElement;
   }
 
-  /** TODO */
+  /**
+   * Returns whether the element has any child elements.
+   *
+   * @returns {boolean} TRUE if the there is any child element, FALSE otherwise
+   * @since 0.2.0
+   */
   protected hasChildren(): boolean {
     return this.children.length > 0;
   }

--- a/src/TextDocument.ts
+++ b/src/TextDocument.ts
@@ -24,61 +24,46 @@ export class TextDocument extends OdfElement {
 
   /**
    * Adds a heading at the end of the document.
-   * If a text is given, this will be set as text content of the paragraph.
-   * If the heading level is omitted, it defaults to 1.
+   * If a text is given, this will be set as text content of the heading.
    *
-   * @param {string} [text] The optional text content of the heading
-   * @param {number} [headingLevel] The optional heading level
+   * @param {string} [text] The text content of the heading
+   * @param {number} [level=1] The heading level; defaults to 1 if omitted
    * @returns {Heading} The newly added heading
    * @since 0.1.0
    */
-  public addHeading(text?: string, headingLevel?: number): Heading {
-    const heading = new Heading(text, headingLevel);
-    this.appendElement(heading);
+  public addHeading(text?: string, level = 1): Heading {
+    const heading = new Heading(text, level);
+    this.append(heading);
 
     return heading;
   }
 
   /**
-   * Adds a paragraph at the end of the document.
-   * If a text is given, this will be set as text content of the paragraph.
-   *
-   * @param {string} [text] The optional text content of the paragraph
-   * @returns {Paragraph} The newly added paragraph
-   * @since 0.1.0
-   */
-  public addParagraph(text?: string): Paragraph {
-    const paragraph = new Paragraph(text);
-    this.appendElement(paragraph);
-
-    return paragraph;
-  }
-
-  /**
-   * Adds a list at the end of the document.
+   * Adds an empty list at the end of the document.
    *
    * @returns {List} The newly added list
    * @since 0.2.0
    */
   public addList(): List {
     const list = new List();
-    this.appendElement(list);
+    this.append(list);
 
     return list;
   }
 
-  /** @inheritDoc */
-  public toString(): string {
-    /* tslint:disable-next-line:max-line-length */
-    const document = new DOMImplementation().createDocument(
-      "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
-      OdfElementName.OfficeDocument,
-      null);
-    const root = document.firstChild;
+  /**
+   * Adds a paragraph at the end of the document.
+   * If a text is given, this will be set as text content of the paragraph.
+   *
+   * @param {string} [text] The text content of the paragraph
+   * @returns {Paragraph} The newly added paragraph
+   * @since 0.1.0
+   */
+  public addParagraph(text?: string): Paragraph {
+    const paragraph = new Paragraph(text);
+    this.append(paragraph);
 
-    this.toXML(document, root as Element);
-
-    return new XMLSerializer().serializeToString(document);
+    return paragraph;
   }
 
   /**
@@ -92,7 +77,26 @@ export class TextDocument extends OdfElement {
     const writeFileAsync = promisify(writeFile);
     const xml = this.toString();
 
-    return writeFileAsync(filePath, XML_DECLARATION + xml);
+    return writeFileAsync(filePath, xml);
+  }
+
+  /**
+   * Returns the string representation of this document in flat open document xml format.
+   *
+   * @returns {string} The string representation of this document
+   * @since 0.1.0
+   * @deprecated since version 0.3.0; use {@link TextDocument#saveFlat} instead
+   */
+  public toString(): string {
+    const document = new DOMImplementation().createDocument(
+      "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
+      OdfElementName.OfficeDocument,
+      null);
+    const root = document.firstChild;
+
+    this.toXML(document, root as Element);
+
+    return XML_DECLARATION + new XMLSerializer().serializeToString(document);
   }
 
   /** @inheritDoc */

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,11 @@ export { TextDocument } from "./TextDocument";
 
 // style
 export { HorizontalAlignment } from "./style/HorizontalAlignment";
+export { Style } from "./style/Style";
 
 // text
 export { Heading } from "./text/Heading";
+export { Hyperlink } from "./text/HyperLink";
 export { List } from "./text/List";
 export { ListItem } from "./text/ListItem";
 export { Paragraph } from "./text/Paragraph";

--- a/src/style/Style.ts
+++ b/src/style/Style.ts
@@ -4,7 +4,7 @@ import { OdfElementName } from "../OdfElementName";
 import { HorizontalAlignment } from "./HorizontalAlignment";
 
 /**
- * TODO
+ * This class represents the style of a paragraph.
  *
  * @since 0.1.0
  */
@@ -21,23 +21,54 @@ export class Style {
   }
 
   /**
-   * TODO
+   * Returns the name of the style.
+   * The name is computed to make sure equal styles feature equal names and reflects the current comnfiguration.
    *
-   * @returns {string} TODO
+   * @returns {string} The name of the style
    * @since 0.1.0
    */
   public getName(): string {
     const hash = createHash("md5");
 
+    hash.update(this.horizontalAlignment);
     hash.update(this.shouldBreakPageBefore ? "pb" : "");
 
     return hash.digest("hex");
   }
 
   /**
-   * TODO
+   * Sets the horizontal alignment setting of this paragraph.
    *
-   * @returns {boolean} TODO
+   * @param {HorizontalAlignment} horizontalAlignment The horizontal alignment setting
+   * @since 0.1.0
+   */
+  public setHorizontalAlignment(horizontalAlignment: HorizontalAlignment): void {
+    this.horizontalAlignment = horizontalAlignment;
+  }
+
+  /**
+   * Returns the horizontal alignment setting of this paragraph.
+   *
+   * @returns {HorizontalAlignment} The horizontal alignment setting
+   * @since 0.2.0
+   */
+  public getHorizontalAlignment(): HorizontalAlignment {
+    return this.horizontalAlignment;
+  }
+
+  /**
+   * Inserts a new page break to the document before the corresponding element.
+   *
+   * @since 0.1.0
+   */
+  public setPageBreakBefore(): void {
+    this.shouldBreakPageBefore = true;
+  }
+
+  /**
+   * Returns whether the style represents the default style.
+   *
+   * @returns {boolean} TRUE if the style equals the default style, FALSE otherwise
    * @since 0.1.0
    */
   public isDefault(): boolean {
@@ -46,39 +77,9 @@ export class Style {
   }
 
   /**
-   * TODO
+   * Transforms the style element into Open Document Format.
    *
-   * @returns {HorizontalAlignment} TODO
-   * @since 0.2.0
-   */
-  public getHorizontalAlignment(): HorizontalAlignment {
-    return this.horizontalAlignment;
-  }
-
-  /**
-   * TODO
-   *
-   * @param {HorizontalAlignment} horizontalAlignment TODO
-   * @since 0.1.0
-   */
-  public setHorizontalAlignment(horizontalAlignment: HorizontalAlignment): void {
-    this.horizontalAlignment = horizontalAlignment;
-  }
-
-  /**
-   * TODO
-   *
-   * @param {boolean} shouldBreakBefore TODO
-   * @since 0.1.0
-   */
-  public setPageBreakBefore(shouldBreakBefore: boolean): void {
-    this.shouldBreakPageBefore = shouldBreakBefore;
-  }
-
-  /**
-   * TODO
-   *
-   * @param {Document} document TODO
+   * @param {Document} document The XML document
    * @since 0.1.0
    */
   public toXML(document: Document): void {
@@ -92,9 +93,9 @@ export class Style {
     if (automaticStylesElement.childNodes.length > 0) {
       /* tslint:disable-next-line:prefer-for-of*/
       for (let i = 0; i < automaticStylesElement.childNodes.length; i++) {
-        const existingStyleElement = automaticStylesElement.childNodes[i];
+        const existingStyleElement = automaticStylesElement.childNodes[i] as Element;
         const nameAttribute = existingStyleElement.attributes.getNamedItem(OdfAttributeName.StyleName);
-        if (nameAttribute.value === styleName) {
+        if (nameAttribute !== null && nameAttribute.value === styleName) {
           return;
         }
       }
@@ -119,10 +120,11 @@ export class Style {
   }
 
   /**
-   * TODO
+   * Returns the `automatic-styles` element of the document.
+   * If there is no such element yet, it will be created.
    *
-   * @param {Document} document TODO
-   * @returns {Element} TODO
+   * @param {Document} document The XML document
+   * @returns {Element} The documents `automatic-styles` element
    */
   private getAutomaticStylesElement(document: Document): Element {
     const rootNode = document.firstChild as Element;
@@ -137,10 +139,10 @@ export class Style {
   }
 
   /**
-   * TODO
+   * Creates and returns the `automatic-styles` element for the document.
    *
-   * @param {Document} document TODO
-   * @returns {Element} TODO
+   * @param {Document} document The XML document
+   * @returns {Element} The newly created `automatic-styles` element
    */
   private createAutomaticStylesElement(document: Document): Element {
     const rootNode = document.firstChild as Element;

--- a/src/text/Heading.ts
+++ b/src/text/Heading.ts
@@ -9,49 +9,44 @@ import { Paragraph } from "./Paragraph";
  */
 export class Heading extends Paragraph {
   public static DEFAULT_LEVEL = 1;
-  private outlineLevel: number;
 
   /**
    * Creates a heading
    *
-   * @param {string} [text] The optional text content of the heading
-   * @param {number} headingLevel The outline level of this heading
+   * @param {string} [text] The text content of the heading
+   * @param {number} [level] The heading level; defaults to 1 if omitted
    * @since 0.1.0
    */
-  public constructor(text?: string, headingLevel = Heading.DEFAULT_LEVEL) {
+  public constructor(text?: string, private level = Heading.DEFAULT_LEVEL) {
     super(text);
 
-    this.setHeadingLevel(headingLevel);
+    this.setLevel(level);
   }
 
   /**
-   * Sets the outline level of this heading.
+   * Sets the level of this heading.
    *
-   * @param {number} headingLevel The outline level
+   * @param {number} level The heading level
    * @since 0.1.0
    */
-  public setHeadingLevel(headingLevel: number): void {
-    if (headingLevel > Heading.DEFAULT_LEVEL) {
-      this.outlineLevel = headingLevel;
-    } else {
-      this.outlineLevel = Heading.DEFAULT_LEVEL;
-    }
+  public setLevel(level: number): void {
+    this.level = level > Heading.DEFAULT_LEVEL ? level : Heading.DEFAULT_LEVEL;
   }
 
   /**
-   * Returns the outline level of this heading.
+   * Returns the level of this heading.
    *
-   * @returns {number} The outline level
+   * @returns {number} The heading level
    * @since 0.1.0
    */
-  public getHeadingLevel(): number {
-    return this.outlineLevel;
+  public getLevel(): number {
+    return this.level;
   }
 
   /** @inheritDoc */
   protected createElement(document: Document): Element {
     const heading = document.createElement(OdfElementName.TextHeading);
-    heading.setAttribute(OdfAttributeName.TextOutlineLevel, this.outlineLevel.toString(10));
+    heading.setAttribute(OdfAttributeName.TextOutlineLevel, this.level.toString(10));
 
     return heading;
   }

--- a/src/text/HyperLink.ts
+++ b/src/text/HyperLink.ts
@@ -1,18 +1,20 @@
 import { OdfAttributeName } from "../OdfAttributeName";
 import { OdfElementName } from "../OdfElementName";
-import { Text } from "./Text";
+import { OdfTextElement } from "./OdfTextElement";
+
+const LINK_TYPE = "simple";
 
 /**
  * This class represents a hyperlink in a paragraph.
  *
  * @since 0.3.0
  */
-export class Hyperlink extends Text {
+export class Hyperlink extends OdfTextElement {
   /**
    * Creates a hyperlink
    *
    * @param {string} text The text content of the hyperlink
-   * @param {string} uri The URI of the hyperlink
+   * @param {string} uri The target URI of the hyperlink
    * @since 0.3.0
    */
   public constructor(text: string, private uri: string) {
@@ -20,23 +22,23 @@ export class Hyperlink extends Text {
   }
 
   /**
-   * Returns the URI of this hyperlink.
+   * Sets the target URI for this hyperlink.
    *
-   * @returns {string} The URI of this hyperlink
-   * @since 0.3.0
-   */
-  public getURI(): string {
-    return this.uri;
-  }
-
-  /**
-   * Sets the URI for this hyperlink.
-   *
-   * @param {string} uri The new URI of this hyperlink
+   * @param {string} uri The new target URI
    * @since 0.3.0
    */
   public setURI(uri: string): void {
     this.uri = uri;
+  }
+
+  /**
+   * Returns the target URI of this hyperlink.
+   *
+   * @returns {string} The target URI
+   * @since 0.3.0
+   */
+  public getURI(): string {
+    return this.uri;
   }
 
   /** @inheritDoc */
@@ -47,15 +49,18 @@ export class Hyperlink extends Text {
       return;
     }
 
+    if (this.uri === undefined) {
+      return super.toXML(document, parent);
+    }
+
     (document.firstChild as Element).setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
 
     const hyperlink = document.createElement(OdfElementName.TextHyperlink);
-    hyperlink.setAttribute(OdfAttributeName.XlinkType, "simple");
+    hyperlink.setAttribute(OdfAttributeName.XlinkType, LINK_TYPE);
     hyperlink.setAttribute(OdfAttributeName.XlinkHref, this.uri);
+    parent.appendChild(hyperlink);
 
     const textNode = document.createTextNode(text);
     hyperlink.appendChild(textNode);
-
-    parent.appendChild(hyperlink);
   }
 }

--- a/src/text/List.ts
+++ b/src/text/List.ts
@@ -21,18 +21,18 @@ export class List extends OdfElement {
   /**
    * Adds a new list item with the specified text or adds the specified item to the list.
    *
-   * @param {string | ListItem} [item] The optional text content of the new item or the item to add
-   * @returns {ListItem} The added list item
+   * @param {string | ListItem} [item] The text content of the new item or the item to add
+   * @returns {ListItem} The newly added list item
    * @since 0.2.0
    */
   public addItem(item?: string | ListItem): ListItem {
     if (item instanceof ListItem) {
-      this.appendElement(item);
+      this.append(item);
       return item;
     }
 
     const listItem = new ListItem(item);
-    this.appendElement(listItem);
+    this.append(listItem);
 
     return listItem;
   }
@@ -41,19 +41,19 @@ export class List extends OdfElement {
    * Inserts a new list item with the specified text or inserts the specified item at the specified position.
    * The item is inserted before the item at the specified position.
    *
-   * @param {number} position The index to insert. The start number is 0
+   * @param {number} position The index at which to insert the list item (starting from 0).
    * @param {string | ListItem} item The text content of the new item or the item to insert
-   * @returns {ListItem} The added list item
+   * @returns {ListItem} The newly added list item
    * @since 0.2.0
    */
   public insertItem(position: number, item: string | ListItem): ListItem {
     if (item instanceof ListItem) {
-      this.insertElement(position, item);
+      this.insert(position, item);
       return item;
     }
 
     const listItem = new ListItem(item);
-    this.insertElement(position, listItem);
+    this.insert(position, listItem);
 
     return listItem;
   }
@@ -62,49 +62,35 @@ export class List extends OdfElement {
    * Returns the item at the specified position in this list.
    * If an invalid position is given, undefined is returned.
    *
-   * @param {number} position The index to insert. The start number is 0
-   * @returns {ListItem | undefined} The list item at the specified position or undefined if the position is invalid
+   * @param {number} position The index of the requested the list item (starting from 0).
+   * @returns {ListItem | undefined} The list item at the specified position
+   * or undefined if there is no list item at the specified position
    * @since 0.2.0
    */
   public getItem(position: number): ListItem | undefined {
-    return this.getElement(position) as ListItem;
+    return this.get(position) as ListItem;
   }
 
   /**
-   * Returns the item at the specified position in this list.
-   * If an invalid position is given, undefined is returned.
+   * Returns all list items.
    *
-   * @returns {ListItem[]} The list item at the specified position or undefined if the position is invalid
+   * @returns {ListItem[]} A copy of the list of list items
    * @since 0.2.0
    */
   public getItems(): ListItem[] {
-    return this.getElements() as ListItem[];
+    return this.getAll() as ListItem[];
   }
 
   /**
-   * Replaces the item at the specified position with the specified item.
+   * Removes the list item from the specified position.
    *
-   * @param {number} position The position to put the specified item. The start number is 0
-   * @param {string | ListItem} item The text content of the new item or the item to insert
-   * @returns {ListItem | undefined} The previous item at the position or undefined if the position is invalid
+   * @param {number} position The index of the list item to remove (starting from 0).
+   * @returns {ListItem | undefined} The removed list item
+   * or undefined if there is no list item at the specified position
    * @since 0.2.0
    */
-  public setItem(position: number, item: string | ListItem): ListItem | undefined {
-    const newItem = item instanceof ListItem ? item : new ListItem(item);
-
-    return this.setElement(position, newItem) as ListItem;
-  }
-
-  /**
-   * Removes the item at the specified position from this list.
-   * If an invalid position is given, undefined is returned.
-   *
-   * @param {number} position The index of the item to be removed. The start number is 0
-   * @returns {ListItem | undefined} The removed item or undefined if the position is invalid
-   * @since 0.2.0
-   */
-  public removeItem(position: number): ListItem | undefined {
-    return this.removeElement(position) as ListItem;
+  public removeItemAt(position: number): ListItem | undefined {
+    return this.removeAt(position) as ListItem;
   }
 
   /**
@@ -116,7 +102,7 @@ export class List extends OdfElement {
     let removedElement;
 
     do {
-      removedElement = this.removeElement(0);
+      removedElement = this.removeAt(0);
     } while (removedElement !== undefined);
   }
 
@@ -127,7 +113,7 @@ export class List extends OdfElement {
    * @since 0.2.0
    */
   public size(): number {
-    return this.getElements().length;
+    return this.getAll().length;
   }
 
   /** @inheritDoc */

--- a/src/text/ListItem.ts
+++ b/src/text/ListItem.ts
@@ -13,14 +13,14 @@ export class ListItem extends OdfElement {
   /**
    * Creates a list item
    *
-   * @param {string} [text] The optional text content
+   * @param {string} [text] The text content of the list item
    * @since 0.2.0
    */
   public constructor(text?: string) {
     super();
 
     this.paragraph = new Paragraph(text);
-    this.appendElement(this.paragraph);
+    this.append(this.paragraph);
   }
 
   /** @inheritDoc */

--- a/src/text/OdfTextElement.ts
+++ b/src/text/OdfTextElement.ts
@@ -6,7 +6,7 @@ import { OdfElementName } from "../OdfElementName";
  *
  * @since 0.3.0
  */
-export class Text extends OdfElement {
+export class OdfTextElement extends OdfElement {
   /**
    * Creates a text
    *
@@ -18,16 +18,6 @@ export class Text extends OdfElement {
   }
 
   /**
-   * Returns the text content.
-   *
-   * @returns {string} The text content
-   * @since 0.3.0
-   */
-  public getText(): string {
-    return this.text;
-  }
-
-  /**
    * Sets the new text content.
    *
    * @param {string} text The new text content
@@ -35,6 +25,16 @@ export class Text extends OdfElement {
    */
   public setText(text: string): void {
     this.text = text;
+  }
+
+  /**
+   * Returns the text content.
+   *
+   * @returns {string} The text content
+   * @since 0.3.0
+   */
+  public getText(): string {
+    return this.text;
   }
 
   /** @inheritDoc */

--- a/test/TextDocument.spec.ts
+++ b/test/TextDocument.spec.ts
@@ -25,7 +25,7 @@ describe(TextDocument.name, () => {
   it("return the basis document", () => {
     const result = document.toString();
 
-    expect(result).toEqual(baseDocument);
+    expect(result).toEqual(XML_DECLARATION + baseDocument);
   });
 
   it("write a flat document", async (done) => {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -1,11 +1,12 @@
 import { readFile, unlink } from "fs";
 import { promisify } from "util";
 import { HorizontalAlignment } from "../src/style/HorizontalAlignment";
+import { Style } from "../src/style/Style";
 import { TextDocument, XML_DECLARATION } from "../src/TextDocument";
 
 const FILEPATH = "./integration.fodt";
 
-describe(TextDocument.name, () => {
+describe("integration", () => {
   afterAll(async (done) => {
     const unlinkAsync = promisify(unlink);
 
@@ -21,24 +22,30 @@ describe(TextDocument.name, () => {
     document.addHeading("Second heading", 2);
 
     const para1 = document.addParagraph("The quick, brown fox jumps over a lazy dog.");
-    para1.appendText("\nSome more text");
-    para1.setHorizontalAlignment(HorizontalAlignment.Center);
+    para1.addText("\nSome more text");
+    para1.setStyle(new Style());
+    para1.getStyle().setHorizontalAlignment(HorizontalAlignment.Center);
 
     const heading20 = document.addHeading("List");
-    heading20.setPageBreak();
+    heading20.setStyle(new Style());
+    heading20.getStyle().setPageBreakBefore();
 
     const list = document.addList();
     list.addItem("first item");
     list.addItem("second item");
 
     const heading30 = document.addHeading("Another chapter");
-    heading30.setPageBreak();
+    heading30.setStyle(new Style());
+    heading30.getStyle().setPageBreakBefore();
 
     const para2 = document.addParagraph("This is just an ");
-    para2.appendHyperlink("example", "http://example.org");
-    para2.appendText(".");
+    para2.addHyperlink("example", "http://example.org");
+    para2.addText(".");
 
     await document.saveFlat(FILEPATH);
+
+    // TODO use snapshot testing
+
     done();
   });
 });

--- a/test/style/Style.spec.ts
+++ b/test/style/Style.spec.ts
@@ -1,0 +1,105 @@
+import { HorizontalAlignment } from "../../src/style/HorizontalAlignment";
+import { Style } from "../../src/style/Style";
+import { Paragraph } from "../../src/text/Paragraph";
+import { TextDocument } from "../../src/TextDocument";
+
+describe(Style.name, () => {
+  let document: TextDocument;
+  let paragraph: Paragraph;
+  let testStyle: Style;
+
+  beforeEach(() => {
+    document = new TextDocument();
+    paragraph = document.addParagraph();
+    testStyle = new Style();
+  });
+
+  it("set a style", () => {
+    testStyle.setPageBreakBefore();
+
+    paragraph.setStyle(testStyle);
+
+    expect(document.toString()).toMatch(/<style:style style:family="paragraph" style:name="([a-z0-9]+)">/);
+  });
+
+  it("not set a style if it is default", () => {
+    paragraph.setStyle(testStyle);
+
+    expect(document.toString()).not.toMatch(/<style:style style:family="paragraph" style:name="([a-z0-9]+)">/);
+  });
+
+  describe("#getName", () => {
+    it("return same name for equal styles", () => {
+      const testStyle1 = new Style();
+      const testStyle2 = new Style();
+
+      expect(testStyle1.getName()).toEqual(testStyle2.getName());
+
+      testStyle1.setHorizontalAlignment(HorizontalAlignment.Center);
+      testStyle2.setHorizontalAlignment(HorizontalAlignment.Center);
+
+      expect(testStyle1.getName()).toEqual(testStyle2.getName());
+    });
+
+    it("return different names for different styles", () => {
+      const testStyle1 = new Style();
+      testStyle1.setPageBreakBefore();
+
+      const testStyle2 = new Style();
+      testStyle2.setHorizontalAlignment(HorizontalAlignment.Center);
+      testStyle2.setPageBreakBefore();
+
+      expect(testStyle1.getName()).not.toEqual(testStyle2.getName());
+    });
+  });
+
+  describe("#setHorizontalAlignment", () => {
+    it("set the horizontal alignment", () => {
+      testStyle.setHorizontalAlignment(HorizontalAlignment.Center);
+      paragraph.setStyle(testStyle);
+
+      /* tslint:disable-next-line:max-line-length */
+      expect(document.toString()).toMatch(/<style:style style:family="paragraph" style:name="([a-z0-9]+)"><style:paragraph-properties fo:text-align="center"\/><\/style:style>/);
+    });
+  });
+
+  describe("#getHorizontalAlignment", () => {
+    it("return the current horizontal alignment", () => {
+      testStyle.setHorizontalAlignment(HorizontalAlignment.Center);
+
+      expect(testStyle.getHorizontalAlignment()).toBe(HorizontalAlignment.Center);
+    });
+  });
+
+  describe("#setPageBreakBefore", () => {
+    it("set the page break property to the paragraph style", () => {
+      testStyle.setPageBreakBefore();
+      paragraph.setStyle(testStyle);
+
+      /* tslint:disable-next-line:max-line-length */
+      expect(document.toString()).toMatch(/<style:style style:family="paragraph" style:name="([a-z0-9]+)"><style:paragraph-properties fo:break-before="page"\/><\/style:style>/);
+    });
+  });
+
+  describe("#isDefault", () => {
+    it("return true if the style equals the default style", () => {
+      expect(testStyle.isDefault()).toBe(true);
+
+      testStyle.setHorizontalAlignment(HorizontalAlignment.Center);
+      testStyle.setHorizontalAlignment(HorizontalAlignment.Default);
+
+      expect(testStyle.isDefault()).toBe(true);
+    });
+
+    it("return false if any property of the style differs from the default style", () => {
+      testStyle.setHorizontalAlignment(HorizontalAlignment.Center);
+
+      expect(testStyle.isDefault()).toBe(false);
+
+      testStyle.setHorizontalAlignment(HorizontalAlignment.Default);
+      testStyle.setPageBreakBefore();
+
+      expect(testStyle.isDefault()).toBe(false);
+    });
+  });
+});

--- a/test/text/Heading.spec.ts
+++ b/test/text/Heading.spec.ts
@@ -9,61 +9,63 @@ describe(Heading.name, () => {
     document = new TextDocument();
   });
 
-  it("add text namespace", () => {
-    document.addHeading();
+  describe("#addHeading", () => {
+    it("add text namespace", () => {
+      document.addHeading();
 
-    const documentAsString = document.toString();
-    expect(documentAsString).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
+      const documentAsString = document.toString();
+      expect(documentAsString).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
+    });
+
+    it("insert an empty heading with default level 1", () => {
+      document.addHeading();
+
+      const documentAsString = document.toString();
+      expect(documentAsString).toMatch(/<text:h text:outline-level="1"\/>/);
+    });
+
+    it("insert a heading with given text and default level 1", () => {
+      document.addHeading("heading");
+
+      const documentAsString = document.toString();
+      expect(documentAsString).toMatch(/<text:h text:outline-level="1">heading<\/text:h>/);
+    });
+
+    it("insert a heading with given text and given level", () => {
+      document.addHeading("heading", 2);
+
+      const documentAsString = document.toString();
+      expect(documentAsString).toMatch(/<text:h text:outline-level="2">heading<\/text:h>/);
+    });
   });
 
-  it("insert an empty heading with default level 1", () => {
-    document.addHeading();
-
-    const documentAsString = document.toString();
-    expect(documentAsString).toMatch(/<text:h text:outline-level="1"\/>/);
-  });
-
-  it("insert a heading with given text and default level 1", () => {
-    document.addHeading("heading");
-
-    const documentAsString = document.toString();
-    expect(documentAsString).toMatch(/<text:h text:outline-level="1">heading<\/text:h>/);
-  });
-
-  it("insert a heading with given text and given level", () => {
-    document.addHeading("heading", 2);
-
-    const documentAsString = document.toString();
-    expect(documentAsString).toMatch(/<text:h text:outline-level="2">heading<\/text:h>/);
-  });
-
-  describe("#setHeadingLevel", () => {
+  describe("#setLevel", () => {
     beforeEach(() => {
       heading = document.addHeading("Heading", 2);
     });
 
     it("change the current level to the given value", () => {
-      heading.setHeadingLevel(3);
-      const headingLevel = heading.getHeadingLevel();
+      heading.setLevel(3);
+      const headingLevel = heading.getLevel();
 
       expect(headingLevel).toBe(3);
     });
 
     it("change the current level to the default value, if the given value is invalid", () => {
-      heading.setHeadingLevel(-2);
-      const headingLevel = heading.getHeadingLevel();
+      heading.setLevel(-2);
+      const headingLevel = heading.getLevel();
 
       expect(headingLevel).toBe(Heading.DEFAULT_LEVEL);
     });
   });
 
-  describe("#getHeadingLevel", () => {
+  describe("#getLevel", () => {
     beforeEach(() => {
       heading = document.addHeading("heading", 2);
     });
 
     it("return the current level", () => {
-      const headingLevel = heading.getHeadingLevel();
+      const headingLevel = heading.getLevel();
 
       expect(headingLevel).toBe(2);
     });

--- a/test/text/Hyperlink.spec.ts
+++ b/test/text/Hyperlink.spec.ts
@@ -1,0 +1,70 @@
+import { Heading } from "../../src/text/Heading";
+import { Hyperlink } from "../../src/text/HyperLink";
+import { TextDocument } from "../../src/TextDocument";
+
+describe(Hyperlink.name, () => {
+  const testText = "some text";
+  const testUri = "http://example.org/";
+
+  let document: TextDocument;
+
+  beforeEach(() => {
+    document = new TextDocument();
+  });
+
+  describe("#addHyperlink", () => {
+    it("add xlink namespace", () => {
+      document.addParagraph().addHyperlink("some linked text", testUri);
+
+      expect(document.toString()).toMatch(/xmlns:xlink="http:\/\/www.w3.org\/1999\/xlink"/);
+    });
+
+    it("append a linked text", () => {
+      document.addParagraph(testText).addHyperlink(" some linked text", testUri);
+
+      const documentAsString = document.toString();
+      /* tslint:disable-next-line:max-line-length */
+      expect(documentAsString).toMatch(/<text:p>some text<text:a xlink:type="simple" xlink:href="http:\/\/example.org\/"> some linked text<\/text:a><\/text:p>/);
+    });
+
+    it("not create a hyperlink if text is empty", () => {
+      document.addParagraph(testText).addHyperlink("", testUri);
+
+      const documentAsString = document.toString();
+      expect(documentAsString).toMatch(/<text:p>some text<\/text:p>/);
+    });
+
+    it("not create a hyperlink but add the text if URI is empty", () => {
+      document.addParagraph(testText).addHyperlink(" some linked text", undefined);
+
+      const documentAsString = document.toString();
+      expect(documentAsString).toMatch(/<text:p>some text some linked text<\/text:p>/);
+    });
+  });
+
+  describe("#setURI", () => {
+    let hyperlink: Hyperlink;
+
+    beforeEach(() => {
+      hyperlink = document.addParagraph().addHyperlink(testText, testUri);
+    });
+
+    it("change the current URI to the given value", () => {
+      hyperlink.setURI("localhost");
+
+      expect(hyperlink.getURI()).toBe("localhost");
+    });
+  });
+
+  describe("#getURI", () => {
+    let hyperlink: Hyperlink;
+
+    beforeEach(() => {
+      hyperlink = document.addParagraph().addHyperlink(testText, testUri);
+    });
+
+    it("return the current URI", () => {
+      expect(hyperlink.getURI()).toBe(testUri);
+    });
+  });
+});

--- a/test/text/List.spec.ts
+++ b/test/text/List.spec.ts
@@ -63,29 +63,31 @@ describe(List.name, () => {
     });
 
     it("insert item at the specified position and return the added item", () => {
-      const addedItem = list.insertItem(2, "new");
+      const insertedItem = list.insertItem(2, "new");
 
-      expect(addedItem).toEqual(itemToAdd);
+      expect(insertedItem).toEqual(itemToAdd);
       expect(list.getItems()).toEqual([testItem1, testItem2, itemToAdd, testItem3]);
     });
 
     it("add new items to the specified position and return the added item", () => {
-      const addedItem = list.insertItem(2, itemToAdd);
+      const insertedItem = list.insertItem(2, itemToAdd);
 
-      expect(addedItem).toBe(itemToAdd);
+      expect(insertedItem).toBe(itemToAdd);
       expect(list.getItems()).toEqual([testItem1, testItem2, itemToAdd, testItem3]);
     });
 
-    xit("insert item at the front of the list if position is negative", () => {
-      list.insertItem(-2, itemToAdd);
+    it("insert item at the front of the list if position is negative", () => {
+      const insertedItem = list.insertItem(-2, itemToAdd);
 
-      // TODO how to test? getItem(0)
+      expect(insertedItem).toBe(itemToAdd);
+      expect(list.getItems()).toEqual([itemToAdd, testItem1, testItem2, testItem3]);
     });
 
-    xit("insert item at the end of the list if position is larger than the size of the list", () => {
-      list.insertItem(10, itemToAdd);
+    it("insert item at the end of the list if position is larger than the size of the list", () => {
+      const insertedItem = list.insertItem(10, itemToAdd);
 
-      // TODO how to test? getItem(0)
+      expect(insertedItem).toBe(itemToAdd);
+      expect(list.getItems()).toEqual([testItem1, testItem2, testItem3, itemToAdd]);
     });
   });
 
@@ -102,13 +104,13 @@ describe(List.name, () => {
       expect(item).toEqual(testItem2);
     });
 
-    xit("return undefined if the specified position is less then 0", () => {
+    it("return undefined if the specified position is less then 0", () => {
       const item = list.getItem(-2);
 
       expect(item).toBeUndefined();
     });
 
-    xit("return undefined if the specified position is larger than the list size", () => {
+    it("return undefined if the specified position is larger than the list size", () => {
       const item = list.getItem(10);
 
       expect(item).toBeUndefined();
@@ -127,33 +129,7 @@ describe(List.name, () => {
     });
   });
 
-  describe("#setItem", () => {
-    let itemToAdd: ListItem;
-
-    beforeEach(() => {
-      list.addItem(testItem1);
-      list.addItem(testItem2);
-      list.addItem(testItem3);
-
-      itemToAdd = new ListItem("new");
-    });
-
-    it("replace the item at the specified position and return the previous item", () => {
-      const addedItem = list.setItem(2, "new");
-
-      expect(addedItem).toEqual(testItem3);
-      expect(itemToAdd).toEqual(list.getItem(2));
-    });
-
-    it("replace the item at the specified position and return the previous item", () => {
-      const addedItem = list.setItem(2, itemToAdd);
-
-      expect(addedItem).toEqual(testItem3);
-      expect(itemToAdd).toEqual(list.getItem(2));
-    });
-  });
-
-  describe("#removeItem", () => {
+  describe("#removeItemAt", () => {
     beforeEach(() => {
       list.addItem(testItem1);
       list.addItem(testItem2);
@@ -161,20 +137,20 @@ describe(List.name, () => {
     });
 
     it("remove the item at the specified position and return it", () => {
-      const removedItem = list.removeItem(1);
+      const removedItem = list.removeItemAt(1);
 
       expect(removedItem).toEqual(testItem2);
       expect(list.getItems()).toEqual([testItem1, testItem3]);
     });
 
-    xit("return undefined if the specified position is less then 0", () => {
-      const removedItem = list.removeItem(-2);
+    it("return undefined if the specified position is less then 0", () => {
+      const removedItem = list.removeItemAt(-2);
 
       expect(removedItem).toBeUndefined();
     });
 
-    xit("return undefined if the specified position is larger than the list size", () => {
-      const removedItem = list.removeItem(10);
+    it("return undefined if the specified position is larger than the list size", () => {
+      const removedItem = list.removeItemAt(10);
 
       expect(removedItem).toBeUndefined();
     });


### PR DESCRIPTION
general: rewrite of the public API

The public API (class names and methods) was reworked in order to use the terminology of the [Open Document Format](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html).

Styles cannot be set directly on a paragraph any longer but on the `Style` that is bound to a paragraph.