### PR TITLE
Enable TravisCI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+dist: trusty
+sudo: false
+
+language: node_js
+node_js: v8
+
+deploy:
+  - provider: npm
+    skip_cleanup: true
+    on:
+      tags: true
+    email: "$NPM_EMAIL"
+    api_key: "$NPM_TOKEN"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# simple-odf
+# simple-odf 
 
 Open Document Format made easy using pure JavaScript and Node.js
 
+[![Linux Build][https://travis-ci.org/connium/simple-odf.svg]](https://travis-ci.org/connium/simple-odf)
 [![Dependencies](https://david-dm.org/connium/simple-odf.svg)](https://david-dm.org/connium/simple-odf)
 [![Known Vulnerabilities](https://snyk.io/test/github/connium/simple-odf/badge.svg)](https://snyk.io/test/github/connium/simple-odf)
 [![Version](https://img.shields.io/npm/v/simple-odf.svg)](https://www.npmjs.com/package/simple-odf)


### PR DESCRIPTION
For tests and npm publishing.

Secure variables `NPM_EMAIL` and `NPM_TOKEN` would have to be created in TravisCI interface.

- [ ] ~~Code coverage with CodeCov~~ (see #19)
- [x] npm deploy on tag
- [x] tests and linting (thanks to `pretest` script)

closes #17 