### PR TITLE
Text breaks if \r\n is entered as text of a paragraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **chore:** Update dependencies and fix jest configuration
 - **general:** Full rewrite of the public API to use the terminology of the Open Document Format
 
+### Fixed
+- **paragraph:** Text breaks if `\r\n` is entered as text of a paragraph, closes [#15](https://github.com/connium/simple-odf/issues/15)
+
 ## [0.2.0] (2018-01-12)
 ### Added
 - **docs:** Add CHANGELOG

--- a/src/text/OdfTextElement.ts
+++ b/src/text/OdfTextElement.ts
@@ -70,6 +70,8 @@ export class OdfTextElement extends OdfElement {
           this.appendTabNode(document, parent);
           str = "";
           break;
+        case "\r":
+          break;
         default:
           str += currentChar;
           break;

--- a/test/text/Paragraph.spec.ts
+++ b/test/text/Paragraph.spec.ts
@@ -82,6 +82,12 @@ describe(Paragraph.name, () => {
     expect(document.toString()).toMatch(/<text:p> some <text:s\/>spacey <text:s c="2"\/>text <text:s c="3"\/><\/text:p>/);
   });
 
+  it("ignore carriage return character", () => {
+    document.addParagraph("some text\r\nsome\r more text");
+
+    expect(document.toString()).toMatch(/<text:p>some text<text:line-break\/>some more text<\/text:p>/);
+  });
+
   describe("#addHyperlink", () => {
     it("append a linked text", () => {
       document.addParagraph("some text").addHyperlink(" some linked text", "http://example.org/");


### PR DESCRIPTION
paragraph: Ignore carriage return character in text

If a text contains a carriage return character, the character is ignored and not added to the final document.

Fixes: #15 