### PR TITLE
Types for Image, TabStop and TabStopType are not exported

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.github/
 .vscode/
 coverage/
 examples/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased] (2018-??-??)
+### Fixed
+- **paragraph:** Types for Image, TabStop and TabStopType are not exported, closes [#24](https://github.com/connium/simple-odf/issues/24)
 
 ## [0.3.0] (2018-05-10)
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,13 @@
 export { TextDocument } from "./TextDocument";
 
+// draw
+export { Image } from "./draw/Image";
+
 // style
 export { HorizontalAlignment } from "./style/HorizontalAlignment";
 export { Style } from "./style/Style";
+export { TabStop } from "./style/TabStop";
+export { TabStopType } from "./style/TabStopType";
 
 // text
 export { Heading } from "./text/Heading";


### PR DESCRIPTION
paragraph: Add image, tabstop, tabstoptype to default export

Export the `Image`, `TabStop` and `TabStopType` classes from the `index.ts`.
Additionally the .github folder, which contains the issue templates, was added to the .npmignore.

Fixes: #24 