### PR TITLE
Declare all XML namespaces on creation of the text document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased] (2018-??-??)
+### Changed
+- **document:** Declare all namespaces on creation of the text document, closes [#30](https://github.com/connium/simple-odf/issues/30)
 
 ## [0.5.0] (2018-06-01)
 ### Added

--- a/src/TextDocument.ts
+++ b/src/TextDocument.ts
@@ -128,6 +128,8 @@ export class TextDocument extends OdfElement {
 
   /** @inheritDoc */
   protected toXml(document: Document, root: Element): void {
+    this.setXmlNamespaces(root);
+
     root.setAttribute(OdfAttributeName.OfficeMimetype, "application/vnd.oasis.opendocument.text");
     root.setAttribute(OdfAttributeName.OfficeVersion, OFFICE_VERSION);
 
@@ -143,7 +145,21 @@ export class TextDocument extends OdfElement {
   }
 
   /**
-   * Adds the `font-face-decls` element and the font faces if any font needs to bne declared.
+   * Declares the used XML namespaces.
+   *
+   * @param {Element} root The root element of the document which will be used as parent
+   */
+  private setXmlNamespaces(root: Element): void {
+    root.setAttribute("xmlns:draw", "urn:oasis:names:tc:opendocument:xmlns:drawing:1.0");
+    root.setAttribute("xmlns:fo", "urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0");
+    root.setAttribute("xmlns:style", "urn:oasis:names:tc:opendocument:xmlns:style:1.0");
+    root.setAttribute("xmlns:svg", "urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0");
+    root.setAttribute("xmlns:text", "urn:oasis:names:tc:opendocument:xmlns:text:1.0");
+    root.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+  }
+
+  /**
+   * Adds the `font-face-decls` element and the font faces if any font needs to be declared.
    *
    * @param {Document} document The XML document
    * @param {Element} root The element which will be used as parent
@@ -152,8 +168,6 @@ export class TextDocument extends OdfElement {
     if (this.fonts.length === 0) {
       return;
     }
-
-    root.setAttribute("xmlns:svg", "urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0");
 
     const fontFaceDeclsElement = document.createElement(OdfElementName.OfficeFontFaceDeclarations);
     root.appendChild(fontFaceDeclsElement);

--- a/src/draw/Image.ts
+++ b/src/draw/Image.ts
@@ -48,8 +48,6 @@ export class Image extends OdfElement {
 
   /** @inheritDoc */
   protected toXml(document: Document, parent: Element): void {
-    (document.firstChild as Element).setAttribute("xmlns:draw", "urn:oasis:names:tc:opendocument:xmlns:drawing:1.0");
-
     const frameElement = document.createElement(OdfElementName.DrawFrame);
     parent.appendChild(frameElement);
 

--- a/src/style/StyleHelper.ts
+++ b/src/style/StyleHelper.ts
@@ -35,8 +35,6 @@ export class StyleHelper {
    */
   private static createAutomaticStylesElement(document: Document): Element {
     const rootNode = document.firstChild as Element;
-    rootNode.setAttribute("xmlns:style", "urn:oasis:names:tc:opendocument:xmlns:style:1.0");
-    rootNode.setAttribute("xmlns:fo", "urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0");
 
     const officeBodyElement = rootNode.getElementsByTagName(OdfElementName.OfficeBody)[0];
 

--- a/src/text/HyperLink.ts
+++ b/src/text/HyperLink.ts
@@ -53,8 +53,6 @@ export class Hyperlink extends OdfTextElement {
       return super.toXml(document, parent);
     }
 
-    (document.firstChild as Element).setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
-
     const hyperlink = document.createElement(OdfElementName.TextHyperlink);
     parent.appendChild(hyperlink);
     hyperlink.setAttribute(OdfAttributeName.XlinkType, LINK_TYPE);

--- a/src/text/Paragraph.ts
+++ b/src/text/Paragraph.ts
@@ -134,8 +134,6 @@ export class Paragraph extends OdfElement {
 
   /** @inheritDoc */
   protected toXml(document: Document, parent: Element): void {
-    (document.firstChild as Element).setAttribute("xmlns:text", "urn:oasis:names:tc:opendocument:xmlns:text:1.0");
-
     const paragraph = this.createElement(document);
     parent.appendChild(paragraph);
 

--- a/test/TextDocument.spec.ts
+++ b/test/TextDocument.spec.ts
@@ -11,7 +11,7 @@ const FILEPATH = "./test.fodt";
 
 describe(TextDocument.name, () => {
   /* tslint:disable-next-line:max-line-length */
-  const baseDocument = '<office:document office:mimetype="application/vnd.oasis.opendocument.text" office:version="1.2" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"><office:body><office:text/></office:body></office:document>';
+  const baseDocument = '<office:document xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" office:mimetype="application/vnd.oasis.opendocument.text" office:version="1.2" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"><office:body><office:text/></office:body></office:document>';
   let document: TextDocument;
 
   beforeEach(() => {
@@ -26,13 +26,33 @@ describe(TextDocument.name, () => {
     done();
   });
 
-  describe("#declareFont", () => {
-    it("add svg namespace", () => {
-      document.declareFont("Springfield", "Springfield", FontPitch.Variable);
+  describe("namespace declaration", () => {
+    it("add draw namespace", () => {
+      expect(document.toString()).toMatch(/xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"/);
+    });
 
+    it("add fo namespace", () => {
+      expect(document.toString()).toMatch(/xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"/);
+    });
+
+    it("add style namespace", () => {
+      expect(document.toString()).toMatch(/xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"/);
+    });
+
+    it("add svg namespace", () => {
       expect(document.toString()).toMatch(/xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"/);
     });
 
+    it("add text namespace", () => {
+      expect(document.toString()).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
+    });
+
+    it("add xlink namespace", () => {
+      expect(document.toString()).toMatch(/xmlns:xlink="http:\/\/www.w3.org\/1999\/xlink"/);
+    });
+  });
+
+  describe("#declareFont", () => {
     it("add font declaration to document", () => {
       document.declareFont("Springfield", "Springfield", FontPitch.Variable);
 

--- a/test/draw/Image.spec.ts
+++ b/test/draw/Image.spec.ts
@@ -47,10 +47,6 @@ describe(Image.name, () => {
       image = document.addParagraph().addImage(join(__dirname, "..", "data", "ODF.png"));
     });
 
-    it("add draw namespace", () => {
-      expect(document.toString()).toMatch(/xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"/);
-    });
-
     it("append a draw frame with image and base64 encoded image", () => {
       const regex = new RegExp("<draw:frame text:anchor-type=\"paragraph\">"
         + "<draw:image>"

--- a/test/text/Heading.spec.ts
+++ b/test/text/Heading.spec.ts
@@ -10,13 +10,6 @@ describe(Heading.name, () => {
   });
 
   describe("#addHeading", () => {
-    it("add text namespace", () => {
-      document.addHeading();
-
-      const documentAsString = document.toString();
-      expect(documentAsString).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
-    });
-
     it("insert an empty heading with default level 1", () => {
       document.addHeading();
 

--- a/test/text/Hyperlink.spec.ts
+++ b/test/text/Hyperlink.spec.ts
@@ -12,12 +12,6 @@ describe(Hyperlink.name, () => {
   });
 
   describe("#addHyperlink", () => {
-    it("add xlink namespace", () => {
-      document.addParagraph().addHyperlink("some linked text", testUri);
-
-      expect(document.toString()).toMatch(/xmlns:xlink="http:\/\/www.w3.org\/1999\/xlink"/);
-    });
-
     it("append a linked text", () => {
       document.addParagraph(testText).addHyperlink(" some linked text", testUri);
 

--- a/test/text/Paragraph.spec.ts
+++ b/test/text/Paragraph.spec.ts
@@ -11,12 +11,6 @@ describe(Paragraph.name, () => {
   });
 
   describe("#addParagraph", () => {
-    it("add text namespace", () => {
-      document.addParagraph();
-
-      expect(document.toString()).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
-    });
-
     it("insert an empty paragraph", () => {
       document.addParagraph();
 


### PR DESCRIPTION
document: declare all XML namespaces in the document upfront instead of declaring them dynamically on usage.

Fixes #30 