### PR TITLE
refactor: always use millimeter as unit, except for font sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - **meta:** Use `Date` instead of `number` when dealing with dates
-- **chore:** Update dev dependencies, place test code next to production code, mention contributors in package.json
+- **style:** Always use millimeter as unit, except for font size
 - **refactor:** Split API and serialization logic, closes [#60](https://github.com/connium/simple-odf/issues/60)
+- **chore:** Update dev dependencies, place test code next to production code, mention contributors in package.json
 
 ## [0.6.0] (2018-10-12)
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -2039,16 +2039,16 @@ Creates a tab stop to be set to the style of a paragraph.
 
 #### Parameters
 - [position] <code>number</code>  
-The position of the tab stop in centimeters relative to the left margin.
+The position of the tab stop in millimeters relative to the left margin.
 If a negative value is given, the `position` will be set to `0`.
 - [type] <code>TabStopType</code>  
 The type of the tab stop. Defaults to `TabStopType.Left`.
 
 **Example**  
 ```js
-// creates a right aligned tab stop with a distance of 4 cm from the left margin
-const tabStop4 = new TabStop(4, TabStopType.Right);
-paragraph.getStyle().addTabStop(tabStop4);
+// creates a right aligned tab stop with a distance of 40 mm from the left margin
+const tabStop40 = new TabStop(40, TabStopType.Right);
+paragraph.getStyle().addTabStop(tabStop40);
 ```
 
 * * *
@@ -2060,7 +2060,7 @@ Sets the position of this tab stop.
 
 #### Parameters
 - position <code>number</code>  
-The position of the tab stop in centimeters relative to the left margin.
+The position of the tab stop in millimeters relative to the left margin.
 If a negative value is given, the `position` will be set to `0`.
 
 **Since**: 0.3.0  
@@ -2073,7 +2073,7 @@ If a negative value is given, the `position` will be set to `0`.
 Returns the position of this tab stop.
 
 **Return value**  
-<code>number</code> - The position of this tab stop in centimeters
+<code>number</code> - The position of this tab stop in millimeters
 
 **Since**: 0.3.0  
 

--- a/src/style/IParagraphProperties.ts
+++ b/src/style/IParagraphProperties.ts
@@ -43,7 +43,7 @@ export interface IParagraphProperties {
    * If a tab stop at the same position already exists, the new tab stop will not be added.
    * The tab stops will be ordered by their position.
    *
-   * @param {number} position The position of the tab stop in centimeters relative to the left margin.
+   * @param {number} position The position of the tab stop in millimeters relative to the left margin.
    * @param {TabStopType} type The type of the tab stop. Defaults to `TabStopType.Left`.
    * @returns {TabStop | undefined} The newly added tab stop
    * or `undefined` if a tab stop at the same position already exists

--- a/src/style/ParagraphProperties.spec.ts
+++ b/src/style/ParagraphProperties.spec.ts
@@ -162,7 +162,7 @@ describe(ParagraphProperties.name, () => {
       paragraph.setStyle(testStyle);
 
       /* tslint:disable-next-line:max-line-length */
-      expect(document.toString()).toMatch(/<style:style style:family="paragraph" style:name="([a-z0-9]+)"><style:paragraph-properties><style:tab-stops><style:tab-stop style:position="23cm"\/><\/style:tab-stops><\/style:paragraph-properties><\/style:style>/);
+      expect(document.toString()).toMatch(/<style:style style:family="paragraph" style:name="([a-z0-9]+)"><style:paragraph-properties><style:tab-stops><style:tab-stop style:position="23mm"\/><\/style:tab-stops><\/style:paragraph-properties><\/style:style>/);
     });
   });
 });

--- a/src/style/TabStop.spec.ts
+++ b/src/style/TabStop.spec.ts
@@ -97,10 +97,10 @@ describe(TabStop.name, () => {
       paragraph.setStyle(style);
 
       const documentAsString = document.toString();
-      expect(documentAsString).toMatch(/<style:tab-stop style:position="2cm" style:type="center"\/>/);
-      expect(documentAsString).toMatch(/<style:tab-stop style:position="4cm" style:type="char"\/>/);
-      expect(documentAsString).toMatch(/<style:tab-stop style:position="6cm"\/>/);
-      expect(documentAsString).toMatch(/<style:tab-stop style:position="8cm" style:type="right"\/>/);
+      expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center"\/>/);
+      expect(documentAsString).toMatch(/<style:tab-stop style:position="4mm" style:type="char"\/>/);
+      expect(documentAsString).toMatch(/<style:tab-stop style:position="6mm"\/>/);
+      expect(documentAsString).toMatch(/<style:tab-stop style:position="8mm" style:type="right"\/>/);
     });
   });
 });

--- a/src/style/TabStop.ts
+++ b/src/style/TabStop.ts
@@ -9,9 +9,9 @@ import { TabStopType } from "./TabStopType";
  * To become effective they must be set to the style of the respective paragraph.
  *
  * @example
- * // creates a right aligned tab stop with a distance of 4 cm from the left margin
- * const tabStop4 = new TabStop(4, TabStopType.Right);
- * paragraph.getStyle().addTabStop(tabStop4);
+ * // creates a right aligned tab stop with a distance of 40 mm from the left margin
+ * const tabStop40 = new TabStop(40, TabStopType.Right);
+ * paragraph.getStyle().addTabStop(tabStop40);
  *
  * @since 0.3.0
  */
@@ -19,7 +19,7 @@ export class TabStop {
   /**
    * Creates a tab stop to be set to the style of a paragraph.
    *
-   * @param {number} [position] The position of the tab stop in centimeters relative to the left margin.
+   * @param {number} [position] The position of the tab stop in millimeters relative to the left margin.
    * If a negative value is given, the `position` will be set to `0`.
    * @param {TabStopType} [type] The type of the tab stop. Defaults to `TabStopType.Left`.
    * @since 0.3.0
@@ -31,7 +31,7 @@ export class TabStop {
   /**
    * Sets the position of this tab stop.
    *
-   * @param {number} position The position of the tab stop in centimeters relative to the left margin.
+   * @param {number} position The position of the tab stop in millimeters relative to the left margin.
    * If a negative value is given, the `position` will be set to `0`.
    * @since 0.3.0
    */
@@ -42,7 +42,7 @@ export class TabStop {
   /**
    * Returns the position of this tab stop.
    *
-   * @returns {number} The position of this tab stop in centimeters
+   * @returns {number} The position of this tab stop in millimeters
    * @since 0.3.0
    */
   public getPosition(): number {
@@ -80,7 +80,7 @@ export class TabStop {
     const tabStopElement = document.createElement(OdfElementName.StyleTabStop);
     parent.appendChild(tabStopElement);
 
-    tabStopElement.setAttribute(OdfAttributeName.StylePosition, `${this.position}cm`);
+    tabStopElement.setAttribute(OdfAttributeName.StylePosition, `${this.position}mm`);
     if (this.type !== TabStopType.Left) {
       tabStopElement.setAttribute(OdfAttributeName.StyleType, this.type);
     }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -80,8 +80,8 @@ xdescribe("integration", () => {
     it("tab stops", () => {
       const paragraph = body.addParagraph("first\tsecond\tthird");
       paragraph.setStyle(new ParagraphStyle());
-      paragraph.getStyle().addTabStop(new TabStop(4));
-      paragraph.getStyle().addTabStop(new TabStop(12, TabStopType.Right));
+      paragraph.getStyle().addTabStop(new TabStop(40));
+      paragraph.getStyle().addTabStop(new TabStop(120, TabStopType.Right));
     });
   });
 


### PR DESCRIPTION
BREAKING CHANGE: The position of tab stops is now regarded as being given in millimeters instead of centimeters.