### PR TITLE
style: add keep-with-next flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - **style:** add common styles
 - **style:** allow page break to be before or after a paragraph, closes [#31](https://github.com/connium/simple-odf/issues/31)
+- **style:** add keep-with-next flag
 - **docs:** add a realistic example
 
 ### Changed

--- a/src/api/style/IParagraphProperties.ts
+++ b/src/api/style/IParagraphProperties.ts
@@ -43,6 +43,21 @@ export interface IParagraphProperties {
   getKeepTogether (): boolean;
 
   /**
+   * TODO
+   *
+   * @since 0.9.0
+   */
+  setKeepWithNext (keepWithNext?: boolean): void;
+
+  /**
+   * TODO
+   *
+   * @returns {boolean} `true` TODO, `false` otherwise
+   * @since 0.9.0
+   */
+  getKeepWithNext (): boolean;
+
+  /**
    * Sets the page break setting of the paragraph.
    *
    * @param {PageBreak} pageBreak The page break setting

--- a/src/api/style/ParagraphProperties.spec.ts
+++ b/src/api/style/ParagraphProperties.spec.ts
@@ -39,6 +39,22 @@ describe(ParagraphProperties.name, () => {
     });
   });
 
+  describe('keep with next', () => {
+    it('return false by default', () => {
+      expect(properties.getKeepWithNext()).toBe(false);
+    });
+
+    it('return previously set state', () => {
+      properties.setKeepWithNext();
+
+      expect(properties.getKeepWithNext()).toBe(true);
+
+      properties.setKeepWithNext(false);
+
+      expect(properties.getKeepWithNext()).toBe(false);
+    });
+  });
+
   describe('page break', () => {
     it('return None by default', () => {
       expect(properties.getPageBreak()).toBe(PageBreak.None);

--- a/src/api/style/ParagraphProperties.ts
+++ b/src/api/style/ParagraphProperties.ts
@@ -7,17 +7,20 @@ import { TabStop } from './TabStop';
 const DEFAULT_HORIZONTAL_ALIGNMENT = HorizontalAlignment.Default;
 const DEFAULT_PAGE_BREAK = PageBreak.None;
 const DEFAULT_KEEP_TOGETHER = false;
+const DEFAULT_KEEP_WITH_NEXT = false;
 
 export class ParagraphProperties implements IParagraphProperties {
   private horizontalAlignment: HorizontalAlignment;
   private pageBreak: PageBreak;
   private shouldKeepTogether: boolean;
+  private shouldKeepWithNext: boolean;
   private tabStops: TabStop[] = [];
 
   public constructor () {
     this.horizontalAlignment = DEFAULT_HORIZONTAL_ALIGNMENT;
     this.pageBreak = DEFAULT_PAGE_BREAK;
     this.shouldKeepTogether = DEFAULT_KEEP_TOGETHER;
+    this.shouldKeepWithNext = DEFAULT_KEEP_WITH_NEXT;
   }
 
   /** @inheritdoc */
@@ -38,6 +41,16 @@ export class ParagraphProperties implements IParagraphProperties {
   /** @inheritdoc */
   public getKeepTogether (): boolean {
     return this.shouldKeepTogether;
+  }
+
+  /** @inheritdoc */
+  setKeepWithNext (keepWithNext = true): void {
+    this.shouldKeepWithNext = keepWithNext;
+  }
+
+  /** @inheritdoc */
+  getKeepWithNext (): boolean {
+    return this.shouldKeepWithNext;
   }
 
   /** @inheritdoc */

--- a/src/api/style/ParagraphStyle.ts
+++ b/src/api/style/ParagraphStyle.ts
@@ -50,6 +50,18 @@ export class ParagraphStyle extends Style implements IParagraphProperties, IText
   }
 
   /** @inheritdoc */
+  public setKeepWithNext (keepWithNext = true): ParagraphStyle {
+    this.paragraphProperties.setKeepWithNext(keepWithNext);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getKeepWithNext (): boolean {
+    return this.paragraphProperties.getKeepWithNext();
+  }
+
+  /** @inheritdoc */
   public setPageBreak (pageBreak: PageBreak): ParagraphStyle {
     this.paragraphProperties.setPageBreak(pageBreak);
 

--- a/src/xml/OdfAttributeName.ts
+++ b/src/xml/OdfAttributeName.ts
@@ -2,6 +2,7 @@ export enum OdfAttributeName {
   FormatBreakAfter = 'fo:break-after',
   FormatBreakBefore = 'fo:break-before',
   FormatKeepTogether = 'fo:keep-together',
+  FormatKeepWithNext = 'fo:keep-with-next',
   FormatColor = 'fo:color',
   FormatFontSize = 'fo:font-size',
   FormatFontStyle = 'fo:font-style',

--- a/src/xml/office/StylesWriter.spec.ts
+++ b/src/xml/office/StylesWriter.spec.ts
@@ -95,6 +95,15 @@ describe(StylesWriter.name, () => {
         expect(documentAsString).toMatch(/<style:paragraph-properties fo:keep-together="always"\/>/);
       });
 
+      it('set keep with next', () => {
+        testStyle.setKeepWithNext(true);
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:keep-with-next="always"\/>/);
+      });
+
       it('set page break before', () => {
         testStyle.setPageBreak(PageBreak.Before);
 

--- a/src/xml/office/StylesWriter.ts
+++ b/src/xml/office/StylesWriter.ts
@@ -76,6 +76,10 @@ export class StylesWriter {
       paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatKeepTogether, 'always');
     }
 
+    if (style.getKeepWithNext() === true) {
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatKeepWithNext, 'always');
+    }
+
     switch (style.getPageBreak()) {
       case PageBreak.Before:
         paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBreakBefore, 'page');

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -65,11 +65,19 @@ xdescribe('integration', () => {
       heading.setStyle(style);
     });
 
+    it('keep with next', () => {
+      const style = new ParagraphStyle();
+      style.setKeepWithNext();
+
+      const heading = body.addParagraph('Keep together with next paragraph');
+      heading.setStyle(style);
+    });
+
     it('keep together', () => {
       const style = new ParagraphStyle();
       style.setKeepTogether();
 
-      const heading = body.addParagraph('Paragraph Formatting');
+      const heading = body.addParagraph('Do\nnot\nsplit\nthis\nparagraph');
       heading.setStyle(style);
     });
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please provide a description above and answer the questions below.

Bug fixes and new features must include tests.

If this is your first contribution, don't forget to add your name to the contributors list in the package.json.
-->

**What kind of change is this PR?**

feature

**What is the current behavior?**

If there is a headline followed by a paragraph and this paragraph does not fit on the same page, it will be placed on the next page while the headline remains on the previous page.

**What is the new behavior (if this is a feature change)?**

On a paragraph style the `keep-with-next` flag can be set to tell the paragraph not to break before the next paragraph.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Changelog has been updated
- [x] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
