### PR TITLE
style: add margin settings to paragraph style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - **style:** add common styles
 - **style:** allow page break to be before or after a paragraph, closes [#31](https://github.com/connium/simple-odf/issues/31)
-- **style:** add keep-with-next flag
-- **style:** add orphan & widdow control, paragraph background, line height
+- **style:** add keep-with-next flag to paragraph style
+- **style:** add orphan & widow control, paragraph background, line height to paragraph style
+- **style:** add margin settings to paragraph style
 - **docs:** add a realistic example
 
 ### Changed

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -19,9 +19,9 @@
   - :heavy_check_mark: Font color
   - :heavy_check_mark: Effects
   - :x: Relief
-  - :soon: Overlining
-  - :soon: Strikethrough
-  - :soon: Underlining
+  - :construction: Overlining
+  - :construction: Strikethrough
+  - :construction: Underlining
 - Position
   - :x: Position
   - :x: Rotation & scaling
@@ -40,31 +40,31 @@
 
 ### Paragraph
 - Indents & spacing
-  - :soon: Indent
-  - :soon: Spacing
-  - :construction: Line spacing
+  - :heavy_check_mark: Indent
+  - :heavy_check_mark: Spacing
+  - :heavy_check_mark: Line spacing
 - Alignment
   - :heavy_check_mark: horizontal
-  - :construction: vertical
+  - :heavy_check_mark: vertical
 - Text flow
   - :x: Hyphenation
   - :heavy_check_mark: Breaks
-  - :construction: Options
+  - :heavy_check_mark: Break control
 - Outline & numbering
   - :x: Outline
   - :x: Numbering
   - :x: Line numbering
 - Tabs
   - :heavy_check_mark: Type
-  - :soon: Fill character
+  - :construction: Fill character
 - Drop caps
 - Borders
-  - :soon: Line arrangement
-  - :soon: Line
+  - :construction: Line arrangement
+  - :construction: Line
   - :x: Spacing to contents
   - :x: Shadow style
-- Area
-  - :construction: Color
+- Background
+  - :heavy_check_mark: Color
   - :x: Gradient
   - :x: Hatching
   - :x: Bitmap
@@ -76,7 +76,7 @@
   - :heavy_check_mark: tab
   - :heavy_check_mark: line break
   - :x: hyphen
-  - :soon: span
+  - :x: span
   - :construction: hyperlink
   - :x: number
 - :construction: List
@@ -95,7 +95,6 @@
 
 <!--
 :x:
-:soon:
 :construction:
 :heavy_check_mark:
 -->

--- a/src/api/office/AutomaticStyles.ts
+++ b/src/api/office/AutomaticStyles.ts
@@ -121,8 +121,13 @@ export class AutomaticStyles implements IStyles {
       hash.update(paragraphStyle.getKeepWithNext() ? 'kwn' : '');
       hash.update('lh' + (paragraphStyle.getLineHeight() || ''));
       hash.update('lhal' + (paragraphStyle.getLineHeightAtLeast() || ''));
+      hash.update('margin-bottom' + paragraphStyle.getMarginBottom());
+      hash.update('margin-left' + paragraphStyle.getMarginLeft());
+      hash.update('margin-right' + paragraphStyle.getMarginRight());
+      hash.update('margin-top' + paragraphStyle.getMarginTop());
       hash.update('orphans' + (paragraphStyle.getOrphans() || ''));
       hash.update(paragraphStyle.getPageBreak().toString());
+      hash.update('text-indent' + paragraphStyle.getTextIndent());
       hash.update(paragraphStyle.getVerticalAlignment());
       hash.update('widows' + (paragraphStyle.getWidows() || ''));
       paragraphStyle.getTabStops().forEach((tabStop) => {

--- a/src/api/style/IParagraphProperties.ts
+++ b/src/api/style/IParagraphProperties.ts
@@ -87,6 +87,51 @@ export interface IParagraphProperties {
   /**
    * @since 0.9.0
    */
+  setMarginBottom (margin: number): void;
+
+  /**
+   * @since 0.9.0
+   */
+  getMarginBottom (): number;
+
+  /**
+   * @since 0.9.0
+   */
+  setMarginLeft (margin: number): void;
+
+  /**
+   * @since 0.9.0
+   */
+  getMarginLeft (): number;
+
+  /**
+   * @since 0.9.0
+   */
+  setMarginRight (margin: number): void;
+
+  /**
+   * @since 0.9.0
+   */
+  getMarginRight (): number;
+
+  /**
+   * @since 0.9.0
+   */
+  setMarginTop (margin: number): void;
+
+  /**
+   * @since 0.9.0
+   */
+  getMarginTop (): number;
+
+  /**
+   * @since 0.9.0
+   */
+  setMargins (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void;
+
+  /**
+   * @since 0.9.0
+   */
   setOrphans (orphans: number | undefined): void;
 
   /**
@@ -109,6 +154,16 @@ export interface IParagraphProperties {
    * @since 0.9.0
    */
   getPageBreak (): PageBreak;
+
+  /**
+   * @since 0.9.0
+   */
+  setTextIndent (textIndent: number): void;
+
+  /**
+   * @since 0.9.0
+   */
+  getTextIndent (): number;
 
   /**
    * @since 0.9.0

--- a/src/api/style/ParagraphProperties.spec.ts
+++ b/src/api/style/ParagraphProperties.spec.ts
@@ -132,6 +132,52 @@ describe(ParagraphProperties.name, () => {
     });
   });
 
+  describe('margin', () => {
+    const testMarginBottom = 13.37;
+    const testMarginLeft = 23.42;
+    const testMarginRight = 12.34;
+    const testMarginTop = 98.76;
+
+    it('return 0 by default', () => {
+      expect(properties.getMarginBottom()).toBe(0);
+      expect(properties.getMarginLeft()).toBe(0);
+      expect(properties.getMarginRight()).toBe(0);
+      expect(properties.getMarginTop()).toBe(0);
+    });
+
+    it('return previously set margin', () => {
+      properties.setMarginBottom(testMarginBottom);
+      properties.setMarginLeft(testMarginLeft);
+      properties.setMarginRight(testMarginRight);
+      properties.setMarginTop(testMarginTop);
+
+      expect(properties.getMarginBottom()).toBe(testMarginBottom);
+      expect(properties.getMarginLeft()).toBe(testMarginLeft);
+      expect(properties.getMarginRight()).toBe(testMarginRight);
+      expect(properties.getMarginTop()).toBe(testMarginTop);
+    });
+
+    it('return previously set margin (set once)', () => {
+      properties.setMargins(testMarginLeft, testMarginRight, testMarginTop, testMarginBottom);
+
+      expect(properties.getMarginBottom()).toBe(testMarginBottom);
+      expect(properties.getMarginLeft()).toBe(testMarginLeft);
+      expect(properties.getMarginRight()).toBe(testMarginRight);
+      expect(properties.getMarginTop()).toBe(testMarginTop);
+    });
+
+    it('ignore invalid value', () => {
+      properties.setMarginBottom(testMarginBottom);
+      properties.setMarginTop(testMarginTop);
+
+      properties.setMarginBottom(0);
+      properties.setMarginTop(0);
+
+      expect(properties.getMarginBottom()).toBe(testMarginBottom);
+      expect(properties.getMarginTop()).toBe(testMarginTop);
+    });
+  });
+
   describe('orphans', () => {
     const testOrphans = 23;
 
@@ -177,6 +223,20 @@ describe(ParagraphProperties.name, () => {
       properties.setPageBreak(PageBreak.After);
 
       expect(properties.getPageBreak()).toBe(PageBreak.After);
+    });
+  });
+
+  describe('text indent', () => {
+    it('return 0 by default', () => {
+      expect(properties.getTextIndent()).toBe(0);
+    });
+
+    it('return previously set indent', () => {
+      const testIndent = 23.42;
+
+      properties.setTextIndent(testIndent);
+
+      expect(properties.getTextIndent()).toBe(testIndent);
     });
   });
 

--- a/src/api/style/ParagraphProperties.ts
+++ b/src/api/style/ParagraphProperties.ts
@@ -10,27 +10,39 @@ import { VerticalAlignment } from './VerticalAlignment';
 const DEFAULT_HORIZONTAL_ALIGNMENT = HorizontalAlignment.Default;
 const DEFAULT_KEEP_TOGETHER = false;
 const DEFAULT_KEEP_WITH_NEXT = false;
+const DEFAULT_MARGIN = 0;
 const DEFAULT_PAGE_BREAK = PageBreak.None;
+const DEFAULT_TEXT_INDENT = 0;
 const DEFAULT_VERTICAL_ALIGNMENT = VerticalAlignment.Default;
 
 export class ParagraphProperties implements IParagraphProperties {
   private backgroundColor: Color | undefined;
   private horizontalAlignment: HorizontalAlignment;
   private lineHeight: number | string | undefined;
+  private marginBottom: number;
+  private marginLeft: number;
+  private marginRight: number;
+  private marginTop: number;
   private minimumLineHeight: number | undefined;
   private orphans: number | undefined;
   private pageBreak: PageBreak;
   private shouldKeepTogether: boolean;
   private shouldKeepWithNext: boolean;
+  private textIndent: number;
   private verticalAlignment: VerticalAlignment;
   private widows: number | undefined;
   private tabStops: TabStop[] = [];
 
   public constructor () {
     this.horizontalAlignment = DEFAULT_HORIZONTAL_ALIGNMENT;
+    this.marginBottom = DEFAULT_MARGIN;
+    this.marginLeft = DEFAULT_MARGIN;
+    this.marginRight = DEFAULT_MARGIN;
+    this.marginTop = DEFAULT_MARGIN;
     this.pageBreak = DEFAULT_PAGE_BREAK;
     this.shouldKeepTogether = DEFAULT_KEEP_TOGETHER;
     this.shouldKeepWithNext = DEFAULT_KEEP_WITH_NEXT;
+    this.textIndent = DEFAULT_TEXT_INDENT;
     this.verticalAlignment = DEFAULT_VERTICAL_ALIGNMENT;
   }
 
@@ -101,6 +113,58 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
+  setMarginBottom (margin: number): void {
+    if (isNonNegativeNumber(margin)) {
+      this.marginBottom = margin;
+    }
+  }
+
+  /** @inheritdoc */
+  getMarginBottom (): number {
+    return this.marginBottom;
+  }
+
+  /** @inheritdoc */
+  setMarginLeft (margin: number): void {
+    this.marginLeft = margin;
+  }
+
+  /** @inheritdoc */
+  getMarginLeft (): number {
+    return this.marginLeft;
+  }
+
+  /** @inheritdoc */
+  setMarginRight (margin: number): void {
+    this.marginRight = margin;
+  }
+
+  /** @inheritdoc */
+  getMarginRight (): number {
+    return this.marginRight;
+  }
+
+  /** @inheritdoc */
+  setMarginTop (margin: number): void {
+    if (isNonNegativeNumber(margin)) {
+      this.marginTop = margin;
+    }
+  }
+
+  /** @inheritdoc */
+  getMarginTop (): number {
+    return this.marginTop;
+  }
+
+  /** @inheritdoc */
+  setMargins (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void {
+    this.setMarginLeft(marginLeft);
+    this.setMarginRight(marginRight);
+    this.setMarginTop(marginTop);
+    this.setMarginBottom(marginBottom);
+  }
+
+  /** @inheritdoc */
   public setOrphans (orphans: number | undefined): void {
     if (isNonNegativeNumber(orphans)) {
       this.orphans = Math.trunc(orphans as number);
@@ -125,6 +189,16 @@ export class ParagraphProperties implements IParagraphProperties {
   /** @inheritdoc */
   public getPageBreak (): PageBreak {
     return this.pageBreak;
+  }
+
+  /** @inheritdoc */
+  setTextIndent (textIndent: number): void {
+    this.textIndent = textIndent;
+  }
+
+  /** @inheritdoc */
+  getTextIndent (): number {
+    return this.textIndent;
   }
 
   /** @inheritdoc */

--- a/src/api/style/ParagraphStyle.ts
+++ b/src/api/style/ParagraphStyle.ts
@@ -99,6 +99,61 @@ export class ParagraphStyle extends Style implements IParagraphProperties, IText
   }
 
   /** @inheritdoc */
+  public setMarginBottom (margin: number): ParagraphStyle {
+    this.paragraphProperties.setMarginBottom(margin);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getMarginBottom (): number {
+    return this.paragraphProperties.getMarginBottom();
+  }
+
+  /** @inheritdoc */
+  public setMarginLeft (margin: number): ParagraphStyle {
+    this.paragraphProperties.setMarginLeft(margin);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getMarginLeft (): number {
+    return this.paragraphProperties.getMarginLeft();
+  }
+
+  /** @inheritdoc */
+  public setMarginRight (margin: number): ParagraphStyle {
+    this.paragraphProperties.setMarginRight(margin);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getMarginRight (): number {
+    return this.paragraphProperties.getMarginRight();
+  }
+
+  /** @inheritdoc */
+  public setMarginTop (margin: number): ParagraphStyle {
+    this.paragraphProperties.setMarginTop(margin);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getMarginTop (): number {
+    return this.paragraphProperties.getMarginTop();
+  }
+
+  /** @inheritdoc */
+  public setMargins (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): ParagraphStyle {
+    this.paragraphProperties.setMargins(marginLeft, marginRight, marginTop, marginBottom);
+
+    return this;
+  }
+
+  /** @inheritdoc */
   public setOrphans (orphans: number | undefined): ParagraphStyle {
     this.paragraphProperties.setOrphans(orphans);
 
@@ -120,6 +175,18 @@ export class ParagraphStyle extends Style implements IParagraphProperties, IText
   /** @inheritdoc */
   public getPageBreak (): PageBreak {
     return this.paragraphProperties.getPageBreak();
+  }
+
+  /** @inheritdoc */
+  public setTextIndent (textIndent: number): ParagraphStyle {
+    this.paragraphProperties.setTextIndent(textIndent);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getTextIndent (): number {
+    return this.paragraphProperties.getTextIndent();
   }
 
   /** @inheritdoc */

--- a/src/api/style/TextProperties.spec.ts
+++ b/src/api/style/TextProperties.spec.ts
@@ -39,22 +39,24 @@ describe(TextProperties.name, () => {
   });
 
   describe('#font size', () => {
+    const testFontSize = 23;
+
     it('return default font size', () => {
       expect(properties.getFontSize()).toBe(12);
     });
 
     it('return previously set font size', () => {
-      const testFontSize = 23;
-
       properties.setFontSize(testFontSize);
 
       expect(properties.getFontSize()).toBe(testFontSize);
     });
 
-    it('set a minimum font size', () => {
+    it('ignore invalid value', () => {
+      properties.setFontSize(testFontSize);
+
       properties.setFontSize(-42);
 
-      expect(properties.getFontSize()).toBe(2);
+      expect(properties.getFontSize()).toBe(testFontSize);
     });
   });
 

--- a/src/api/style/TextProperties.ts
+++ b/src/api/style/TextProperties.ts
@@ -1,9 +1,9 @@
+import { isPositiveLength } from '../util';
 import { Color } from './Color';
 import { ITextProperties } from './ITextProperties';
 import { TextTransformation } from './TextTransformation';
 import { Typeface } from './Typeface';
 
-const MINIMAL_FONT_SIZE = 2;
 const DEFAULT_FONT_SIZE = 12;
 const DEFAULT_TRANSFORMATION = TextTransformation.None;
 const DEFAULT_TYPEFACE = Typeface.Normal;
@@ -55,7 +55,9 @@ export class TextProperties implements ITextProperties {
 
   /** @inheritDoc */
   public setFontSize (size: number): void {
-    this.fontSize = Math.max(size, MINIMAL_FONT_SIZE);
+    if (isPositiveLength(size)) {
+      this.fontSize = size;
+    }
   }
 
   /** @inheritDoc */

--- a/src/api/util/index.ts
+++ b/src/api/util/index.ts
@@ -1,2 +1,3 @@
 export { isNonNegativeNumber } from './isNonNegativeNumber';
 export { isPercent } from './isPercent';
+export { isPositiveLength } from './isPositiveLength';

--- a/src/api/util/isNonNegativeNumber.ts
+++ b/src/api/util/isNonNegativeNumber.ts
@@ -1,6 +1,8 @@
 /**
  * The `isNonNegativeNumber` method returns whether the given value is a non-negative number.
  *
+ * ([0-9]+(\.[0-9]*)?|\.[0-9]+)((cm)|(mm)|(in)|(pt)|(pc)|(px))
+ *
  * @param {any} value The value that is to be checked
  * @returns {boolean} `true` if the given value is a non-negative number, `false` otherwise
  * @private

--- a/src/api/util/isPercent.ts
+++ b/src/api/util/isPercent.ts
@@ -1,6 +1,8 @@
 /**
  * The `isPercent` method returns whether the given value is a percentage.
  *
+ * -?([0-9]+(\.[0-9]*)?|\.[0-9]+)%
+ *
  * @param {any} value The value that is to be checked
  * @returns {boolean} `true` if the given value is a percentage, `false` otherwise
  * @private

--- a/src/api/util/isPositiveLength.ts
+++ b/src/api/util/isPositiveLength.ts
@@ -1,0 +1,12 @@
+/**
+ * The `isPositiveLength` method returns whether the given value is a positive number.
+ *
+ * ([0-9]*[1-9][0-9]*(\.[0-9]*)?|0+\.[0-9]*[1-9][0-9]*|\.[0-9]*[1-9][0-9]*)((cm)|(mm)|(in)|(pt)|(pc)|(px))
+ *
+ * @param {any} value The value that is to be checked
+ * @returns {boolean} `true` if the given value is a positive number, `false` otherwise
+ * @private
+ */
+export function isPositiveLength (value: any): boolean {
+  return typeof value === 'number' && value >= 0;
+}

--- a/src/xml/OdfAttributeName.ts
+++ b/src/xml/OdfAttributeName.ts
@@ -9,8 +9,13 @@ export enum OdfAttributeName {
   FormatKeepTogether = 'fo:keep-together',
   FormatKeepWithNext = 'fo:keep-with-next',
   FormatLineHeight = 'fo:line-height',
+  FormatMarginBottom = 'fo:margin-bottom',
+  FormatMarginLeft = 'fo:margin-left',
+  FormatMarginRight = 'fo:margin-right',
+  FormatMarginTop = 'fo:margin-top',
   FormatOrphans = 'fo:orphans',
   FormatTextAlign = 'fo:text-align',
+  FormatTextIndent = 'fo:text-indent',
   FormatTextTransform = 'fo:text-transform',
   FormatWidows = 'fo:widows',
 

--- a/src/xml/office/StylesWriter.spec.ts
+++ b/src/xml/office/StylesWriter.spec.ts
@@ -140,6 +140,42 @@ describe(StylesWriter.name, () => {
         expect(documentAsString).toMatch(/<style:paragraph-properties style:line-height-at-least="23mm"\/>/);
       });
 
+      it('set margin bottom', () => {
+        testStyle.setMarginBottom(23.42);
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:margin-bottom="23.42mm"\/>/);
+      });
+
+      it('set margin left', () => {
+        testStyle.setMarginLeft(23.42);
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:margin-left="23.42mm"\/>/);
+      });
+
+      it('set margin right', () => {
+        testStyle.setMarginRight(23.42);
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:margin-right="23.42mm"\/>/);
+      });
+
+      it('set margin top', () => {
+        testStyle.setMarginTop(23.42);
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:margin-top="23.42mm"\/>/);
+      });
+
       it('set orphans', () => {
         testStyle.setOrphans(23);
 
@@ -165,6 +201,15 @@ describe(StylesWriter.name, () => {
         const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
         expect(documentAsString).toMatch(/<style:paragraph-properties fo:break-after="page"\/>/);
+      });
+
+      it('set text indent', () => {
+        testStyle.setTextIndent(23.42);
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:text-indent="23.42mm"\/>/);
       });
 
       it('set vertical alignment', () => {

--- a/src/xml/office/StylesWriter.ts
+++ b/src/xml/office/StylesWriter.ts
@@ -105,6 +105,31 @@ export class StylesWriter {
       paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatOrphans, orphans.toString(10));
     }
 
+    const marginLeft = style.getMarginLeft();
+    if (marginLeft !== 0) {
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatMarginLeft, marginLeft.toString(10) + 'mm');
+    }
+
+    const marginRight = style.getMarginRight();
+    if (marginRight !== 0) {
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatMarginRight, marginRight.toString(10) + 'mm');
+    }
+
+    const textIndent = style.getTextIndent();
+    if (textIndent !== 0) {
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatTextIndent, textIndent.toString(10) + 'mm');
+    }
+
+    const marginTop = style.getMarginTop();
+    if (marginTop !== 0) {
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatMarginTop, marginTop.toString(10) + 'mm');
+    }
+
+    const marginBottom = style.getMarginBottom();
+    if (marginBottom !== 0) {
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatMarginBottom, marginBottom.toString(10) + 'mm');
+    }
+
     switch (style.getPageBreak()) {
       case PageBreak.Before:
         paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBreakBefore, 'page');

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -70,8 +70,8 @@ xdescribe('integration', () => {
       const style = new ParagraphStyle();
       style.setBackgroundColor(Color.fromRgb(0, 255, 0));
 
-      const heading = body.addParagraph('Some text with green colored background');
-      heading.setStyle(style);
+      const paragraph = body.addParagraph('Some text with green colored background');
+      paragraph.setStyle(style);
     });
 
     it('align text', () => {
@@ -86,47 +86,72 @@ xdescribe('integration', () => {
       const style = new ParagraphStyle();
       style.setKeepTogether();
 
-      const heading = body.addParagraph('Do\nnot\nsplit\nthis\nparagraph');
-      heading.setStyle(style);
+      const paragraph = body.addParagraph('Do\nnot\nsplit\nthis\nparagraph');
+      paragraph.setStyle(style);
     });
 
     it('keep with next', () => {
       const style = new ParagraphStyle();
       style.setKeepWithNext();
 
-      const heading = body.addParagraph('Keep together with next paragraph');
-      heading.setStyle(style);
+      const paragraph = body.addParagraph('Keep together with next paragraph');
+      paragraph.setStyle(style);
     });
 
     it('line height', () => {
       const style = new ParagraphStyle();
       style.setLineHeight('120%');
 
-      const heading = body.addParagraph('Some text with 120% line height');
-      heading.setStyle(style);
+      const paragraph = body.addParagraph('Some text with 120% line height');
+      paragraph.setStyle(style);
     });
 
     it('line height at least', () => {
       const style = new ParagraphStyle();
       style.setLineHeightAtLeast(40);
 
-      const heading = body.addParagraph('Some text with minimum line height of 40 mm');
-      heading.setStyle(style);
+      const paragraph = body.addParagraph('Some text with minimum line height of 40 mm');
+      paragraph.setStyle(style);
+    });
+
+    it('margin', () => {
+      const style1 = new ParagraphStyle();
+      style1.setMarginLeft(10);
+      style1.setMarginRight(20);
+      style1.setMarginTop(30);
+      style1.setMarginBottom(40);
+
+      const paragraph1 = body.addParagraph('Some text with margins on all four sides');
+      paragraph1.setStyle(style1);
+
+      const style2 = new ParagraphStyle();
+      style2.setMargins(10, 20, 30, 40);
+
+      const paragraph2 = body.addParagraph('Some other text with margins on all four sides but set at the same time');
+      paragraph2.setStyle(style2);
     });
 
     it('orphans', () => {
       const style = new ParagraphStyle();
       style.setOrphans(2);
 
-      const heading = body.addParagraph('Break paragraph after 2 lines of text at the earliest');
-      heading.setStyle(style);
+      const paragraph = body.addParagraph('Break paragraph after 2 lines of text at the earliest');
+      paragraph.setStyle(style);
+    });
+
+    it('text indent', () => {
+      const style = new ParagraphStyle();
+      style.setTextIndent(23);
+
+      const paragraph = body.addParagraph('First line is indented\nwhile the others are not');
+      paragraph.setStyle(style);
     });
 
     it('vertical align text', () => {
       const style = new ParagraphStyle();
       style.setVerticalAlignment(VerticalAlignment.Middle);
 
-      const paragraph = body.addParagraph('Some centered text');
+      const paragraph = body.addParagraph('Some vertically centered text');
       paragraph.setStyle(style);
     });
 
@@ -134,8 +159,8 @@ xdescribe('integration', () => {
       const style = new ParagraphStyle();
       style.setWidows(2);
 
-      const heading = body.addParagraph('Write at least 2 lines of text after a break of the paragraph');
-      heading.setStyle(style);
+      const paragraph = body.addParagraph('Write at least 2 lines of text after a break of the paragraph');
+      paragraph.setStyle(style);
     });
 
     it('tab stops', () => {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please provide a description above and answer the questions below.

Bug fixes and new features must include tests.

If this is your first contribution, don't forget to add your name to the contributors list in the package.json.
-->

**What kind of change is this PR?**

feature

**What is the current behavior?**

**What is the new behavior (if this is a feature change)?**

On the paragraph style it is now possible to configure margins and text indentation.

See [fo:margin-bottom](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#property-fo_margin-bottom), [fo:margin-left](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#property-fo_margin-left), [fo:margin-right](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#property-fo_margin-right), [fo:margin-top](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#property-fo_margin-top), [fo:text-indent](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#property-fo_text-indent) in the OASIS Document Format.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Changelog has been updated
- [x] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
