### PR TITLE
feat(style): add border settings to paragraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **style:** add horizontal alignment of last line and line spacing to paragraph style
 - **style:** add padding settings to paragraph style
 - **style:** add font variant to paragraph style
+- **style:** add border settings to paragraph style
 - **docs:** add a realistic example
 
 ### Changed

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -19,15 +19,15 @@
   - :heavy_check_mark: Font color
   - :heavy_check_mark: Effects
   - :x: Relief
-  - :construction: Overlining
-  - :construction: Strikethrough
-  - :construction: Underlining
+  - :x: Overlining
+  - :x: Strikethrough
+  - :x: Underlining
 - Position
   - :x: Position
   - :x: Rotation & scaling
   - :x: Spacing
 - Hyperlink
-  - :heavy_check_mark: Hyperlink
+  - :x: Hyperlink
   - :x: Events
   - :x: Character Styles
 - Highlighting
@@ -61,7 +61,7 @@
 - Borders
   - :construction: Line arrangement
   - :construction: Line
-  - :x: Spacing to contents
+  - :heavy_check_mark: Padding
   - :x: Shadow style
 - Background
   - :heavy_check_mark: Color

--- a/src/api/office/AutomaticStyles.ts
+++ b/src/api/office/AutomaticStyles.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { Style, StyleFamily, ParagraphStyle } from '../style';
+import { Border, ParagraphStyle, Style, StyleFamily } from '../style';
 import { IStyles } from './IStyles';
 
 interface IStyleInformation {
@@ -116,6 +116,10 @@ export class AutomaticStyles implements IStyles {
       // paragraph properties
       const backgroundColor = paragraphStyle.getBackgroundColor();
       hash.update(backgroundColor !== undefined ? backgroundColor.toHex() : '');
+      hash.update('border-bottom' + this.getBorder(paragraphStyle.getBorderBottom()));
+      hash.update('border-left' + this.getBorder(paragraphStyle.getBorderLeft()));
+      hash.update('border-right' + this.getBorder(paragraphStyle.getBorderRight()));
+      hash.update('border-top' + this.getBorder(paragraphStyle.getBorderTop()));
       hash.update(paragraphStyle.getHorizontalAlignment());
       hash.update(paragraphStyle.getHorizontalAlignmentLastLine());
       hash.update(paragraphStyle.getKeepTogether() ? 'kt' : '');
@@ -151,5 +155,9 @@ export class AutomaticStyles implements IStyles {
     }
 
     return hash.digest('hex');
+  }
+
+  private getBorder (border: Border | undefined): string {
+    return border !== undefined ? border.toString() : '';
   }
 }

--- a/src/api/style/Border.ts
+++ b/src/api/style/Border.ts
@@ -1,0 +1,8 @@
+import { BorderStyle } from './BorderStyle';
+import { Color } from './Color';
+
+export interface Border {
+  width: number;
+  style: BorderStyle;
+  color: Color;
+}

--- a/src/api/style/BorderStyle.ts
+++ b/src/api/style/BorderStyle.ts
@@ -1,0 +1,11 @@
+export enum BorderStyle {
+  None = 'none',
+  Dashed = 'dashed',
+  Dotted = 'dotted',
+  Double = 'double',
+  // Groove = 'groove',
+  // Inset = 'inset',
+  // Outset = 'outset',
+  // Ridge = 'ridge',
+  Solid = 'solid'
+}

--- a/src/api/style/IParagraphProperties.ts
+++ b/src/api/style/IParagraphProperties.ts
@@ -1,3 +1,5 @@
+import { Border } from './Border';
+import { BorderStyle } from './BorderStyle';
 import { Color } from './Color';
 import { HorizontalAlignment } from './HorizontalAlignment';
 import { HorizontalAlignmentLastLine } from './HorizontalAlignmentLastLine';
@@ -23,6 +25,76 @@ export interface IParagraphProperties {
    * @since 0.9.0
    */
   getBackgroundColor (): Color | undefined;
+
+  /**
+   * @since 0.9.0
+   */
+  setBorder (width: number, style: BorderStyle, color: Color): void;
+
+  /**
+   * @since 0.9.0
+   */
+  removeBorder (): void;
+
+  /**
+   * @since 0.9.0
+   */
+  setBorderBottom (width: number, style: BorderStyle, color: Color): void;
+
+  /**
+   * @since 0.9.0
+   */
+  getBorderBottom (): Border | undefined;
+
+  /**
+   * @since 0.9.0
+   */
+  removeBorderBottom (): void;
+
+  /**
+   * @since 0.9.0
+   */
+  setBorderLeft (width: number, style: BorderStyle, color: Color): void;
+
+  /**
+   * @since 0.9.0
+   */
+  getBorderLeft (): Border | undefined;
+
+  /**
+   * @since 0.9.0
+   */
+  removeBorderLeft (): void;
+
+  /**
+   * @since 0.9.0
+   */
+  setBorderRight (width: number, style: BorderStyle, color: Color): void;
+
+  /**
+   * @since 0.9.0
+   */
+  getBorderRight (): Border | undefined;
+
+  /**
+   * @since 0.9.0
+   */
+  removeBorderRight (): void;
+
+  /**
+   * @since 0.9.0
+   */
+  setBorderTop (width: number, style: BorderStyle, color: Color): void;
+
+  /**
+   * @since 0.9.0
+   */
+  getBorderTop (): Border | undefined;
+
+  /**
+   * @since 0.9.0
+   */
+  removeBorderTop (): void;
 
   /**
    * Sets the horizontal alignment setting of this paragraph.
@@ -108,6 +180,11 @@ export interface IParagraphProperties {
   /**
    * @since 0.9.0
    */
+  setMargin (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void;
+
+  /**
+   * @since 0.9.0
+   */
   setMarginBottom (margin: number): void;
 
   /**
@@ -148,17 +225,17 @@ export interface IParagraphProperties {
   /**
    * @since 0.9.0
    */
-  setMargin (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void;
-
-  /**
-   * @since 0.9.0
-   */
   setOrphans (orphans: number | undefined): void;
 
   /**
    * @since 0.9.0
    */
   getOrphans (): number | undefined;
+
+  /**
+   * @since 0.9.0
+   */
+  setPadding (paddingLeft: number, paddingRight: number, paddingTop: number, paddingBottom: number): void;
 
   /**
    * @since 0.9.0
@@ -199,11 +276,6 @@ export interface IParagraphProperties {
    * @since 0.9.0
    */
   getPaddingTop (): number;
-
-  /**
-   * @since 0.9.0
-   */
-  setPadding (paddingLeft: number, paddingRight: number, paddingTop: number, paddingBottom: number): void;
 
   /**
    * Sets the page break setting of the paragraph.

--- a/src/api/style/IParagraphProperties.ts
+++ b/src/api/style/IParagraphProperties.ts
@@ -148,7 +148,7 @@ export interface IParagraphProperties {
   /**
    * @since 0.9.0
    */
-  setMargins (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void;
+  setMargin (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void;
 
   /**
    * @since 0.9.0
@@ -203,7 +203,7 @@ export interface IParagraphProperties {
   /**
    * @since 0.9.0
    */
-  setPaddings (paddingLeft: number, paddingRight: number, paddingTop: number, paddingBottom: number): void;
+  setPadding (paddingLeft: number, paddingRight: number, paddingTop: number, paddingBottom: number): void;
 
   /**
    * Sets the page break setting of the paragraph.

--- a/src/api/style/ParagraphProperties.spec.ts
+++ b/src/api/style/ParagraphProperties.spec.ts
@@ -189,7 +189,7 @@ describe(ParagraphProperties.name, () => {
     });
 
     it('return previously set margin (set once)', () => {
-      properties.setMargins(testMarginLeft, testMarginRight, testMarginTop, testMarginBottom);
+      properties.setMargin(testMarginLeft, testMarginRight, testMarginTop, testMarginBottom);
 
       expect(properties.getMarginBottom()).toBe(testMarginBottom);
       expect(properties.getMarginLeft()).toBe(testMarginLeft);
@@ -267,7 +267,7 @@ describe(ParagraphProperties.name, () => {
     });
 
     it('return previously set padding (set once)', () => {
-      properties.setPaddings(testPaddingLeft, testPaddingRight, testPaddingTop, testPaddingBottom);
+      properties.setPadding(testPaddingLeft, testPaddingRight, testPaddingTop, testPaddingBottom);
 
       expect(properties.getPaddingBottom()).toBe(testPaddingBottom);
       expect(properties.getPaddingLeft()).toBe(testPaddingLeft);

--- a/src/api/style/ParagraphProperties.spec.ts
+++ b/src/api/style/ParagraphProperties.spec.ts
@@ -1,3 +1,5 @@
+import { Border } from './Border';
+import { BorderStyle } from './BorderStyle';
 import { Color } from './Color';
 import { HorizontalAlignment } from './HorizontalAlignment';
 import { HorizontalAlignmentLastLine } from './HorizontalAlignmentLastLine';
@@ -25,6 +27,92 @@ describe(ParagraphProperties.name, () => {
       properties.setBackgroundColor(testColor);
 
       expect(properties.getBackgroundColor()).toBe(testColor);
+    });
+  });
+
+  describe('border', () => {
+    const testBorderWidth = 13.37;
+    const testBorderStyle = BorderStyle.Dashed;
+    const testBorderColor = Color.fromRgb(1, 2, 3);
+    const expectedBorder: Border = {
+      width: testBorderWidth,
+      style: testBorderStyle,
+      color: testBorderColor
+    };
+
+    it('return undefined by default', () => {
+      expect(properties.getBorderBottom()).toBeUndefined();
+      expect(properties.getBorderLeft()).toBeUndefined();
+      expect(properties.getBorderRight()).toBeUndefined();
+      expect(properties.getBorderTop()).toBeUndefined();
+    });
+
+    it('return previously set border', () => {
+      const expectedBorderBottom: Border = { width: 0.23, style: BorderStyle.Dashed, color: testBorderColor };
+      const expectedBorderLeft: Border = { width: 13.37, style: BorderStyle.Dotted, color: testBorderColor };
+      const expectedBorderRight: Border = { width: 42.24, style: BorderStyle.Double, color: testBorderColor };
+      const expectedBorderTop: Border = { width: 12.34, style: BorderStyle.Solid, color: testBorderColor };
+
+      properties.setBorderBottom(0.23, BorderStyle.Dashed, testBorderColor);
+      properties.setBorderLeft(13.37, BorderStyle.Dotted, testBorderColor);
+      properties.setBorderRight(42.24, BorderStyle.Double, testBorderColor);
+      properties.setBorderTop(12.34, BorderStyle.Solid, testBorderColor);
+
+      expect(properties.getBorderBottom()).toEqual(expectedBorderBottom);
+      expect(properties.getBorderLeft()).toEqual(expectedBorderLeft);
+      expect(properties.getBorderRight()).toEqual(expectedBorderRight);
+      expect(properties.getBorderTop()).toEqual(expectedBorderTop);
+    });
+
+    it('return previously set border (set once)', () => {
+      properties.setBorder(testBorderWidth, testBorderStyle, testBorderColor);
+
+      expect(properties.getBorderBottom()).toEqual(expectedBorder);
+      expect(properties.getBorderLeft()).toEqual(expectedBorder);
+      expect(properties.getBorderRight()).toEqual(expectedBorder);
+      expect(properties.getBorderTop()).toEqual(expectedBorder);
+    });
+
+    it('ignore invalid value', () => {
+      properties.setBorderBottom(testBorderWidth, testBorderStyle, testBorderColor);
+      properties.setBorderLeft(testBorderWidth, testBorderStyle, testBorderColor);
+      properties.setBorderRight(testBorderWidth, testBorderStyle, testBorderColor);
+      properties.setBorderTop(testBorderWidth, testBorderStyle, testBorderColor);
+
+      properties.setBorderBottom(-0.1, testBorderStyle, testBorderColor);
+      properties.setBorderLeft(-0.1, testBorderStyle, testBorderColor);
+      properties.setBorderRight(-0.1, testBorderStyle, testBorderColor);
+      properties.setBorderTop(-0.1, testBorderStyle, testBorderColor);
+
+      expect(properties.getBorderBottom()).toEqual(expectedBorder);
+      expect(properties.getBorderLeft()).toEqual(expectedBorder);
+      expect(properties.getBorderRight()).toEqual(expectedBorder);
+      expect(properties.getBorderTop()).toEqual(expectedBorder);
+    });
+
+    it('remove previously set border', () => {
+      properties.setBorder(testBorderWidth, testBorderStyle, testBorderColor);
+
+      properties.removeBorderBottom();
+      properties.removeBorderLeft();
+      properties.removeBorderRight();
+      properties.removeBorderTop();
+
+      expect(properties.getBorderBottom()).toBeUndefined();
+      expect(properties.getBorderLeft()).toBeUndefined();
+      expect(properties.getBorderRight()).toBeUndefined();
+      expect(properties.getBorderTop()).toBeUndefined();
+    });
+
+    it('remove previously set border (remove once)', () => {
+      properties.setBorder(testBorderWidth, testBorderStyle, testBorderColor);
+
+      properties.removeBorder();
+
+      expect(properties.getBorderBottom()).toBeUndefined();
+      expect(properties.getBorderLeft()).toBeUndefined();
+      expect(properties.getBorderRight()).toBeUndefined();
+      expect(properties.getBorderTop()).toBeUndefined();
     });
   });
 

--- a/src/api/style/ParagraphProperties.ts
+++ b/src/api/style/ParagraphProperties.ts
@@ -1,4 +1,6 @@
 import { isNonNegativeNumber, isPercent } from '../util';
+import { Border } from './Border';
+import { BorderStyle } from './BorderStyle';
 import { Color } from './Color';
 import { HorizontalAlignment } from './HorizontalAlignment';
 import { HorizontalAlignmentLastLine } from './HorizontalAlignmentLastLine';
@@ -10,6 +12,10 @@ import { VerticalAlignment } from './VerticalAlignment';
 
 export class ParagraphProperties implements IParagraphProperties {
   private backgroundColor: Color | undefined;
+  private borderBottom: Border | undefined;
+  private borderLeft: Border | undefined;
+  private borderRight: Border | undefined;
+  private borderTop: Border | undefined;
   private horizontalAlignment: HorizontalAlignment;
   private horizontalAlignmentLastLine: HorizontalAlignmentLastLine;
   private lineHeight: number | string | undefined;
@@ -58,6 +64,90 @@ export class ParagraphProperties implements IParagraphProperties {
   /** @inheritdoc */
   public getBackgroundColor (): Color | undefined {
     return this.backgroundColor;
+  }
+
+  /** @inheritdoc */
+  public setBorder (width: number, style: BorderStyle, color: Color): void {
+    this.setBorderBottom(width, style, color);
+    this.setBorderLeft(width, style, color);
+    this.setBorderRight(width, style, color);
+    this.setBorderTop(width, style, color);
+  }
+
+  /** @inheritdoc */
+  public removeBorder (): void {
+    this.removeBorderBottom();
+    this.removeBorderLeft();
+    this.removeBorderRight();
+    this.removeBorderTop();
+  }
+
+  /** @inheritdoc */
+  public setBorderBottom (width: number, style: BorderStyle, color: Color): void {
+    if (isNonNegativeNumber(width)) {
+      this.borderBottom = { width, style, color };
+    }
+  }
+
+  /** @inheritdoc */
+  public getBorderBottom (): Border | undefined {
+    return this.borderBottom;
+  }
+
+  /** @inheritdoc */
+  public removeBorderBottom (): void {
+    this.borderBottom = undefined;
+  }
+
+  /** @inheritdoc */
+  public setBorderLeft (width: number, style: BorderStyle, color: Color): void {
+    if (isNonNegativeNumber(width)) {
+      this.borderLeft = { width, style, color };
+    }
+  }
+
+  /** @inheritdoc */
+  public getBorderLeft (): Border | undefined {
+    return this.borderLeft;
+  }
+
+  /** @inheritdoc */
+  public removeBorderLeft (): void {
+    this.borderLeft = undefined;
+  }
+
+  /** @inheritdoc */
+  public setBorderRight (width: number, style: BorderStyle, color: Color): void {
+    if (isNonNegativeNumber(width)) {
+      this.borderRight = { width, style, color };
+    }
+  }
+
+  /** @inheritdoc */
+  public getBorderRight (): Border | undefined {
+    return this.borderRight;
+  }
+
+  /** @inheritdoc */
+  public removeBorderRight (): void {
+    this.borderRight = undefined;
+  }
+
+  /** @inheritdoc */
+  public setBorderTop (width: number, style: BorderStyle, color: Color): void {
+    if (isNonNegativeNumber(width)) {
+      this.borderTop = { width, style, color };
+    }
+  }
+
+  /** @inheritdoc */
+  public getBorderTop (): Border | undefined {
+    return this.borderTop;
+  }
+
+  /** @inheritdoc */
+  public removeBorderTop (): void {
+    this.borderTop = undefined;
   }
 
   /** @inheritdoc */

--- a/src/api/style/ParagraphProperties.ts
+++ b/src/api/style/ParagraphProperties.ts
@@ -179,7 +179,7 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public setMargins (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void {
+  public setMargin (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void {
     this.setMarginLeft(marginLeft);
     this.setMarginRight(marginRight);
     this.setMarginTop(marginTop);
@@ -252,7 +252,7 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public setPaddings (paddingLeft: number, paddingRight: number, paddingTop: number, paddingBottom: number): void {
+  public setPadding (paddingLeft: number, paddingRight: number, paddingTop: number, paddingBottom: number): void {
     this.setPaddingLeft(paddingLeft);
     this.setPaddingRight(paddingRight);
     this.setPaddingTop(paddingTop);

--- a/src/api/style/ParagraphStyle.ts
+++ b/src/api/style/ParagraphStyle.ts
@@ -1,3 +1,5 @@
+import { Border } from './Border';
+import { BorderStyle } from './BorderStyle';
 import { Color } from './Color';
 import { FontVariant } from './FontVariant';
 import { HorizontalAlignment } from './HorizontalAlignment';
@@ -38,6 +40,96 @@ export class ParagraphStyle extends Style implements IParagraphProperties, IText
   /** @inheritdoc */
   public getBackgroundColor (): Color | undefined {
     return this.paragraphProperties.getBackgroundColor();
+  }
+
+  /** @inheritdoc */
+  public setBorder (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+    this.paragraphProperties.setBorder(width, style, color);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public removeBorder (): ParagraphStyle {
+    this.paragraphProperties.removeBorder();
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public setBorderBottom (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+    this.paragraphProperties.setBorderBottom(width, style, color);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getBorderBottom (): Border | undefined {
+    return this.paragraphProperties.getBorderBottom();
+  }
+
+  /** @inheritdoc */
+  public removeBorderBottom (): ParagraphStyle {
+    this.paragraphProperties.removeBorderBottom();
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public setBorderLeft (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+    this.paragraphProperties.setBorderLeft(width, style, color);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getBorderLeft (): Border | undefined {
+    return this.paragraphProperties.getBorderLeft();
+  }
+
+  /** @inheritdoc */
+  public removeBorderLeft (): ParagraphStyle {
+    this.paragraphProperties.removeBorderLeft();
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public setBorderRight (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+    this.paragraphProperties.setBorderRight(width, style, color);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getBorderRight (): Border | undefined {
+    return this.paragraphProperties.getBorderRight();
+  }
+
+  /** @inheritdoc */
+  public removeBorderRight (): ParagraphStyle {
+    this.paragraphProperties.removeBorderRight();
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public setBorderTop (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+    this.paragraphProperties.setBorderTop(width, style, color);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public getBorderTop (): Border | undefined {
+    return this.paragraphProperties.getBorderTop();
+  }
+
+  /** @inheritdoc */
+  public removeBorderTop (): ParagraphStyle {
+    this.paragraphProperties.removeBorderTop();
+
+    return this;
   }
 
   /** @inheritdoc */

--- a/src/api/style/ParagraphStyle.ts
+++ b/src/api/style/ParagraphStyle.ts
@@ -173,8 +173,8 @@ export class ParagraphStyle extends Style implements IParagraphProperties, IText
   }
 
   /** @inheritdoc */
-  public setMargins (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): ParagraphStyle {
-    this.paragraphProperties.setMargins(marginLeft, marginRight, marginTop, marginBottom);
+  public setMargin (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): ParagraphStyle {
+    this.paragraphProperties.setMargin(marginLeft, marginRight, marginTop, marginBottom);
 
     return this;
   }
@@ -240,12 +240,12 @@ export class ParagraphStyle extends Style implements IParagraphProperties, IText
   }
 
   /** @inheritdoc */
-  public setPaddings (
+  public setPadding (
     paddingLeft: number,
     paddingRight: number,
     paddingTop: number,
     paddingBottom: number): ParagraphStyle {
-    this.paragraphProperties.setPaddings(paddingLeft, paddingRight, paddingTop, paddingBottom);
+    this.paragraphProperties.setPadding(paddingLeft, paddingRight, paddingTop, paddingBottom);
 
     return this;
   }

--- a/src/api/style/index.ts
+++ b/src/api/style/index.ts
@@ -1,3 +1,5 @@
+export { Border } from './Border';
+export { BorderStyle } from './BorderStyle';
 export { Color } from './Color';
 export { FontFace } from './FontFace';
 export { FontFamilyGeneric } from './FontFamilyGeneric';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export { TextBody } from './api/office/TextBody';
 export { TextDocument } from './api/office/TextDocument';
 
 // style
+export { Border } from './api/style/Border';
+export { BorderStyle } from './api/style/BorderStyle';
 export { Color } from './api/style/Color';
 export { FontFace } from './api/style/FontFace';
 export { FontFamilyGeneric } from './api/style/FontFamilyGeneric';

--- a/src/xml/OdfAttributeName.ts
+++ b/src/xml/OdfAttributeName.ts
@@ -1,5 +1,9 @@
 export enum OdfAttributeName {
   FormatBackgroundColor = 'fo:background-color',
+  FormatBorderBottom = 'fo:border-bottom',
+  FormatBorderLeft = 'fo:border-left',
+  FormatBorderRight = 'fo:border-right',
+  FormatBorderTop = 'fo:border-top',
   FormatBreakAfter = 'fo:break-after',
   FormatBreakBefore = 'fo:break-before',
   FormatColor = 'fo:color',

--- a/src/xml/office/StylesWriter.spec.ts
+++ b/src/xml/office/StylesWriter.spec.ts
@@ -1,8 +1,9 @@
 // tslint:disable:no-duplicate-imports
 import { DOMImplementation, XMLSerializer } from 'xmldom';
 import { CommonStyles, AutomaticStyles } from '../../api/office';
-import { Color, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine, PageBreak } from '../../api/style';
-import { ParagraphStyle, TextTransformation, Typeface, TabStop, TabStopType, VerticalAlignment } from '../../api/style';
+import { BorderStyle, Color, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine } from '../../api/style';
+import { PageBreak, ParagraphStyle, TextTransformation, Typeface, TabStop, TabStopType } from '../../api/style';
+import { VerticalAlignment } from '../../api/style';
 import { OdfElementName } from '../OdfElementName';
 import { StylesWriter } from './StylesWriter';
 
@@ -84,6 +85,42 @@ describe(StylesWriter.name, () => {
         const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
         expect(documentAsString).toMatch(/<style:paragraph-properties fo:background-color="#010203"\/>/);
+      });
+
+      it('set border bottom', () => {
+        testStyle.setBorderBottom(23.42, BorderStyle.Dashed, Color.fromRgb(1, 2, 3));
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:border-bottom="23.42mm dashed #010203"\/>/);
+      });
+
+      it('set border left', () => {
+        testStyle.setBorderLeft(23.42, BorderStyle.Dotted, Color.fromRgb(1, 2, 3));
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:border-left="23.42mm dotted #010203"\/>/);
+      });
+
+      it('set border right', () => {
+        testStyle.setBorderRight(23.42, BorderStyle.Double, Color.fromRgb(1, 2, 3));
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:border-right="23.42mm double #010203"\/>/);
+      });
+
+      it('set border top', () => {
+        testStyle.setBorderTop(23.42, BorderStyle.Solid, Color.fromRgb(1, 2, 3));
+
+        stylesWriter.write(commonStyles, testDocument, testRoot);
+        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+        expect(documentAsString).toMatch(/<style:paragraph-properties fo:border-top="23.42mm solid #010203"\/>/);
       });
 
       it('set horizontal alignment', () => {

--- a/src/xml/office/StylesWriter.ts
+++ b/src/xml/office/StylesWriter.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-duplicate-imports
 import { AutomaticStyles, CommonStyles, IStyles } from '../../api/office';
-import { FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine, PageBreak } from '../../api/style';
+import { BorderStyle, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine, PageBreak } from '../../api/style';
 import { ParagraphStyle, Style, StyleFamily, TabStopType, TextTransformation, Typeface } from '../../api/style';
 import { VerticalAlignment } from '../../api/style';
 import { OdfAttributeName } from '../OdfAttributeName';
@@ -157,6 +157,30 @@ export class StylesWriter {
     const backgroundColor = style.getBackgroundColor();
     if (backgroundColor !== undefined) {
       paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBackgroundColor, backgroundColor.toHex());
+    }
+
+    const borderTop = style.getBorderTop();
+    if (borderTop !== undefined && borderTop.width > 0 && borderTop.style !== BorderStyle.None) {
+      const border = `${borderTop.width}mm ${borderTop.style} ${borderTop.color.toHex()}`;
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBorderTop, border);
+    }
+
+    const borderBottom = style.getBorderBottom();
+    if (borderBottom !== undefined && borderBottom.width > 0 && borderBottom.style !== BorderStyle.None) {
+      const border = `${borderBottom.width}mm ${borderBottom.style} ${borderBottom.color.toHex()}`;
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBorderBottom, border);
+    }
+
+    const borderLeft = style.getBorderLeft();
+    if (borderLeft !== undefined && borderLeft.width > 0 && borderLeft.style !== BorderStyle.None) {
+      const border = `${borderLeft.width}mm ${borderLeft.style} ${borderLeft.color.toHex()}`;
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBorderLeft, border);
+    }
+
+    const borderRight = style.getBorderRight();
+    if (borderRight !== undefined && borderRight.width > 0 && borderRight.style !== BorderStyle.None) {
+      const border = `${borderRight.width}mm ${borderRight.style} ${borderRight.color.toHex()}`;
+      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBorderRight, border);
     }
 
     const paddingLeft = style.getPaddingLeft();

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -144,7 +144,7 @@ xdescribe('integration', () => {
       paragraph1.setStyle(style1);
 
       const style2 = new ParagraphStyle();
-      style2.setMargins(10, 20, 30, 40);
+      style2.setMargin(10, 20, 30, 40);
 
       const paragraph2 = body.addParagraph('Some other text with margins on all four sides but set at the same time');
       paragraph2.setStyle(style2);
@@ -169,7 +169,7 @@ xdescribe('integration', () => {
       paragraph1.setStyle(style1);
 
       const style2 = new ParagraphStyle();
-      style2.setPaddings(10, 20, 30, 40);
+      style2.setPadding(10, 20, 30, 40);
 
       const paragraph2 = body.addParagraph('Some other text with padding on all four sides but set at the same time');
       paragraph2.setStyle(style2);

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -4,9 +4,9 @@ import { join } from 'path';
 import { promisify } from 'util';
 import { AnchorType } from '../src/api/draw';
 import { TextBody, TextDocument } from '../src/api/office';
-import { Color, FontPitch, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine } from '../src/api/style';
-import { PageBreak, ParagraphStyle, TabStop, TabStopType, TextTransformation, Typeface } from '../src/api/style';
-import { VerticalAlignment } from '../src/api/style';
+import { BorderStyle, Color, FontPitch, FontVariant, HorizontalAlignment } from '../src/api/style';
+import { HorizontalAlignmentLastLine, PageBreak, ParagraphStyle, TabStop, TabStopType } from '../src/api/style';
+import { TextTransformation, Typeface, VerticalAlignment } from '../src/api/style';
 
 const FILEPATH = './integration.fodt';
 
@@ -72,6 +72,17 @@ xdescribe('integration', () => {
       style.setBackgroundColor(Color.fromRgb(0, 255, 0));
 
       const paragraph = body.addParagraph('Some text with green colored background');
+      paragraph.setStyle(style);
+    });
+
+    it('border', () => {
+      const style = new ParagraphStyle();
+      style.setBorderTop(1, BorderStyle.Dashed, Color.fromRgb(0, 0, 0));
+      style.setBorderBottom(2, BorderStyle.Dotted, Color.fromRgb(255, 0, 0));
+      style.setBorderLeft(3, BorderStyle.Double, Color.fromRgb(0, 255, 0));
+      style.setBorderRight(4, BorderStyle.Solid, Color.fromRgb(0, 0, 255));
+
+      const paragraph = body.addParagraph('Some text with different borders on all sides');
       paragraph.setStyle(style);
     });
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please provide a description above and answer the questions below.

Bug fixes and new features must include tests.

If this is your first contribution, don't forget to add your name to the contributors list in the package.json.
-->

**What kind of change is this PR?**

feature

**What is the current behavior?**

**What is the new behavior (if this is a feature change)?**

On the paragraph style it is now possible to configure the border using the new methods `setBorderBottom`, `setBorderLeft`, `setBorderRight`, `setBorderTop`, `setBorder`.

See [fo:border-bottom](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#property-fo_border-bottom), [fo:border-left](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#property-fo_border-left), [fo:border-right](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#property-fo_border-right), [fo:border-top](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#property-fo_border-top) in the OASIS Document Format.

**Does this PR introduce a breaking change?**

yes

The method `setMargins` was renamed to `setMargin` and the method `setPaddings` was renamed to `setPadding`.

**Please check if the PR fulfills these requirements**

- [x] Changelog has been updated
- [x] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
