### PR TITLE
fix(style): tab stop is added as child of style:style element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **chore:** improve repository structure
 - **chore(ci):** update distribution of Travis CI configuration
 
+### Fixed
+- **fix(style):** tab stop is added as child of style:style element
+
 ## [0.8.0] (2019-02-26)
 ### Added
 - **font:** extend font declaration

--- a/src/api/office/AutomaticStyles.ts
+++ b/src/api/office/AutomaticStyles.ts
@@ -2,10 +2,10 @@ import { createHash } from 'crypto';
 import { Border, ParagraphStyle, Style, StyleFamily } from '../style';
 import { IStyles } from './IStyles';
 
-interface IStyleInformation {
+type IStyleInformation = {
   readonly style: Style;
   readonly name: string;
-}
+};
 
 /**
  * This class represents the automatic styles of a document.

--- a/src/api/style/Border.ts
+++ b/src/api/style/Border.ts
@@ -1,8 +1,8 @@
 import { BorderStyle } from './BorderStyle';
 import { Color } from './Color';
 
-export interface Border {
+export type Border = {
   width: number;
   style: BorderStyle;
   color: Color;
-}
+};

--- a/src/xml/office/StylesWriter.spec.ts
+++ b/src/xml/office/StylesWriter.spec.ts
@@ -330,19 +330,31 @@ describe(StylesWriter.name, () => {
         expect(documentAsString).toMatch(/<style:paragraph-properties fo:widows="23"\/>/);
       });
 
-      it('set tab stops', () => {
-        testStyle.addTabStop(new TabStop(2, TabStopType.Center));
-        testStyle.addTabStop(new TabStop(4, TabStopType.Char));
-        testStyle.addTabStop(new TabStop(6, TabStopType.Left));
-        testStyle.addTabStop(new TabStop(8, TabStopType.Right));
+      describe('tab stops', () => {
+        it('set tab stop', () => {
+          testStyle.addTabStop(new TabStop(2, TabStopType.Left));
 
-        stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+          stylesWriter.write(commonStyles, testDocument, testRoot);
+          const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-        expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center"\/>/);
-        expect(documentAsString).toMatch(/<style:tab-stop style:position="4mm" style:type="char"\/>/);
-        expect(documentAsString).toMatch(/<style:tab-stop style:position="6mm"\/>/);
-        expect(documentAsString).toMatch(/<style:tab-stop style:position="8mm" style:type="right"\/>/);
+          // tslint:disable-next-line:max-line-length
+          expect(documentAsString).toMatch(/<style:paragraph-properties><style:tab-stops><style:tab-stop style:position="2mm"\/><\/style:tab-stops><\/style:paragraph-properties>/);
+        });
+
+        it('set tab stop types', () => {
+          testStyle.addTabStop(new TabStop(2, TabStopType.Center));
+          testStyle.addTabStop(new TabStop(4, TabStopType.Char));
+          testStyle.addTabStop(new TabStop(6, TabStopType.Left));
+          testStyle.addTabStop(new TabStop(8, TabStopType.Right));
+
+          stylesWriter.write(commonStyles, testDocument, testRoot);
+          const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+          expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center"\/>/);
+          expect(documentAsString).toMatch(/<style:tab-stop style:position="4mm" style:type="char"\/>/);
+          expect(documentAsString).toMatch(/<style:tab-stop style:position="6mm"\/>/);
+          expect(documentAsString).toMatch(/<style:tab-stop style:position="8mm" style:type="right"\/>/);
+        });
       });
     });
 

--- a/src/xml/office/StylesWriter.ts
+++ b/src/xml/office/StylesWriter.ts
@@ -221,7 +221,7 @@ export class StylesWriter {
 
     tabStops.forEach((tabStop) => {
       const tabStopElement = document.createElement(OdfElementName.StyleTabStop);
-      parent.appendChild(tabStopElement);
+      tabStopsElement.appendChild(tabStopElement);
 
       tabStopElement.setAttribute(OdfAttributeName.StylePosition, tabStop.getPosition() + 'mm');
       if (tabStop.getType() !== TabStopType.Left) {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please provide a description above and answer the questions below.

Bug fixes and new features must include tests.

If this is your first contribution, don't forget to add your name to the contributors list in the package.json.
-->

**What kind of change is this PR?**

bug fix

**What is the current behavior?**

see #94 

**What is the new behavior (if this is a feature change)?**

Fixed as suggested in the issue #94

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Changelog has been updated
- [ ] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
