### PR TITLE
feat(style): add tab stop character and leader settings to paragraph style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased] (2019-??-??)
+### Added
+- **style:** add tab stop character and leader settings to paragraph style
 
 ## [0.9.0] (2019-05-30)
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,9 +23,6 @@
 <dt><a href="#TextDocument">TextDocument</a></dt>
 <dd><p>This class represents a text document in OpenDocument format.</p>
 </dd>
-<dt><a href="#Color">Color</a></dt>
-<dd><p>This class represents a Color.</p>
-</dd>
 <dt><a href="#FontFace">FontFace</a></dt>
 <dd><p>This class represents a font face declaration.</p>
 <p>It is used to describe the characteristics of a font which is used in the document.
@@ -94,11 +91,7 @@ Path to the image file that should be embedded
 
 **Example**  
 ```js
-document.getBody()
-  .addParagraph()
-  .addImage('/home/homer/myself.png')
-  .setAnchorType(AnchorType.AsChar);
-  .setSize(42, 23);
+const image = new Image('/home/homer/myself.png');
 ```
 
 * * *
@@ -322,14 +315,7 @@ and sets the username of the currently effective user as initial creator.
 
 **Example**  
 ```js
-document.getMeta()
-  .setCreator('Homer Simpson')
-  .setTitle('Node.js meets ODF')
-  .setSubject('ODF document creation')
-  .addKeyword('Node.js')
-  .addKeyword('Open Document Format')
-  .setDescription('ODF text document created with Node.js powered by simple-odf')
-  .setLanguage('en-US');
+const meta = new Meta();
 ```
 
 * * *
@@ -880,8 +866,7 @@ Creates a `CommonStyles` instance that represents the common styles of a documen
 
 **Example**  
 ```js
-document.getCommonStyles()
-  .createParagraphStyle('Summary');
+const commonStyles = new CommonStyles();
 ```
 
 * * *
@@ -1142,11 +1127,6 @@ Creates a `TextDocument` instance that represents a OpenDocument text document.
 **Example**  
 ```js
 const document = new TextDocument();
-document.getMeta().setCreator('Homer Simpson');
-document.getFontFaceDeclarations().create('FreeSans', 'FreeSans', FontPitch.Variable);
-document.getCommonStyles().createParagraphStyle('Summary');
-document.getBody().addHeading('My first document');
-document.saveFlat('/home/homer/document.fodt');
 ```
 
 * * *
@@ -1253,97 +1233,6 @@ Returns the string representation of this document in flat open document xml for
 
 * * *
 
-<a name="Color"></a>
-
-## Color
-This class represents a Color.
-
-**Since**: 0.4.0  
-
-* [Color](#Color)
-    * [`new Color(red, green, blue)`](#new_Color_new)
-    * _instance_
-        * [`.toHex()`](#Color+toHex) ⇒ <code>string</code>
-    * _static_
-        * [`.fromHex(value)`](#Color.fromHex) ⇒ [<code>Color</code>](#Color) \| <code>never</code>
-        * [`.fromRgb(red, green, blue)`](#Color.fromRgb) ⇒ [<code>Color</code>](#Color) \| <code>never</code>
-
-
-* * *
-
-<a name="new_Color_new"></a>
-
-### `new Color(red, green, blue)`
-Creates a new color with the specified channel values.
-
-#### Parameters
-- red <code>number</code>  
-The red channel of the color
-- green <code>number</code>  
-The green channel of the color
-- blue <code>number</code>  
-The blue channel of the color
-
-
-* * *
-
-<a name="Color+toHex"></a>
-
-### `color.toHex()` ⇒ <code>string</code>
-The toHex() method returns a string representing the color as hex string.
-
-**Return value**  
-<code>string</code> - A hex string representing the color
-
-**Since**: 0.4.0  
-
-* * *
-
-<a name="Color.fromHex"></a>
-
-### `Color.fromHex(value)` ⇒ [<code>Color</code>](#Color) \| <code>never</code>
-The `Color.fromHex()` method parses a string argument and returns a color.
-The string is expected to be in `#rrggbb` or `rrggbb` format.
-
-#### Parameters
-- value <code>string</code>  
-The value you want to parse
-
-**Return value**  
-[<code>Color</code>](#Color) \| <code>never</code> - A color parsed from the given value
-
-**Throws**:
-
-- <code>Error</code> If the value cannot be converted to a color
-
-**Since**: 0.4.0  
-
-* * *
-
-<a name="Color.fromRgb"></a>
-
-### `Color.fromRgb(red, green, blue)` ⇒ [<code>Color</code>](#Color) \| <code>never</code>
-The `Color.fromRgb()` method returns a color with the channel arguments.
-
-#### Parameters
-- red <code>number</code>  
-The red channel of the color with a range of 0...255
-- green <code>number</code>  
-The green channel of the color with a range of 0...255
-- blue <code>number</code>  
-The blue channel of the color with a range of 0...255
-
-**Return value**  
-[<code>Color</code>](#Color) \| <code>never</code> - A color parsed from the given value
-
-**Throws**:
-
-- <code>Error</code> If any channel is outside the allowable range
-
-**Since**: 0.4.0  
-
-* * *
-
 <a name="FontFace"></a>
 
 ## FontFace
@@ -1384,8 +1273,9 @@ Indicator whether the font has a fixed or variable width
 
 **Example**  
 ```js
-const font = document.getFontFaceDeclarations().create('FreeSans', 'FreeSans', FontPitch.Variable);
-font.setFontFamilyGeneric(FontFamilyGeneric.Swiss);
+const font = new FontFace('FreeSans', 'FreeSans', FontPitch.Variable);
+const font = new FontFace('FreeSans', 'FreeSans');
+const font = new FontFace('FreeSans');
 ```
 
 * * *
@@ -1611,10 +1501,7 @@ The family of the style
 
 **Example**  
 ```js
-document.getStyleManager().createParagraphStyle('Summary');
-document.getBody()
-  .addParagraph('The quick, brown fox jumps over a lazy dog.')
-  .setStyleName('Summary');
+const style = new Style('Summary', StyleFamily.Paragraph);
 ```
 
 * * *
@@ -1725,71 +1612,206 @@ To become effective they must be set to the style of the respective paragraph.
 **Since**: 0.3.0  
 
 * [TabStop](#TabStop)
-    * [`new TabStop([position], [type])`](#new_TabStop_new)
-    * [`.setPosition(position)`](#TabStop+setPosition)
+    * [`new TabStop(position, [type])`](#new_TabStop_new)
+    * [`.getChar()`](#TabStop+getChar) ⇒ <code>string</code> \| <code>undefined</code>
+    * [`.setChar(char)`](#TabStop+setChar) ⇒ [<code>TabStop</code>](#TabStop)
+    * [`.getLeaderColor()`](#TabStop+getLeaderColor) ⇒ [<code>Color</code>](#new_Color_new) \| <code>undefined</code>
+    * [`.setLeaderColor(color)`](#TabStop+setLeaderColor) ⇒ [<code>TabStop</code>](#TabStop)
+    * [`.getLeaderStyle()`](#TabStop+getLeaderStyle) ⇒ <code>TabStopLeaderStyle</code>
+    * [`.setLeaderStyle(leaderStyle)`](#TabStop+setLeaderStyle) ⇒ [<code>TabStop</code>](#TabStop)
     * [`.getPosition()`](#TabStop+getPosition) ⇒ <code>number</code>
-    * [`.setType(type)`](#TabStop+setType)
+    * [`.setPosition(position)`](#TabStop+setPosition) ⇒ [<code>TabStop</code>](#TabStop)
     * [`.getType()`](#TabStop+getType) ⇒ <code>TabStopType</code>
+    * [`.setType(type)`](#TabStop+setType) ⇒ [<code>TabStop</code>](#TabStop)
 
 
 * * *
 
 <a name="new_TabStop_new"></a>
 
-### `new TabStop([position], [type])`
-Creates a tab stop to be set to the style of a paragraph.
-
-#### Parameters
-- [position] <code>number</code>  
-The position of the tab stop in millimeters relative to the left margin.
-If a negative value is given, the `position` will be set to `0`.
-- [type] <code>TabStopType</code>  
-The type of the tab stop. Defaults to `TabStopType.Left`.
-
-**Example**  
-```js
-// creates a right aligned tab stop with a distance of 40 mm from the left margin
-const tabStop40 = new TabStop(40, TabStopType.Right);
-paragraph.getStyle().addTabStop(tabStop40);
-```
-
-* * *
-
-<a name="TabStop+setPosition"></a>
-
-### `tabStop.setPosition(position)`
-Sets the position of this tab stop.
+### `new TabStop(position, [type])`
+Creates a `TabStop` instance that represents the settings of a tab stop.
 
 #### Parameters
 - position <code>number</code>  
 The position of the tab stop in millimeters relative to the left margin.
 If a negative value is given, the `position` will be set to `0`.
+- [type] <code>TabStopType</code> <code> = TabStopType.Left</code>  
+The type of the tab stop
 
-**Since**: 0.3.0  
+**Example**  
+```js
+const tabStop = new TabStop(23);                     // 23mm, TabStopType.Left
+const tabStop = new TabStop(23, TabStopType.Center); // 23mm, TabStopType.Center
+```
+
+* * *
+
+<a name="TabStop+getChar"></a>
+
+### `tabStop.getChar()` ⇒ <code>string</code> \| <code>undefined</code>
+The `getChar()` method returns delimiter character for tab stops of type `char`.
+
+**Return value**  
+<code>string</code> \| <code>undefined</code> - The delimiter character or `undefined` if the delimiter character is not set
+
+**Example**  
+```js
+const tabStop = new TabStop(23, TabStopType.Char);
+tabStop.getChar();    // undefined
+tabStop.setChar('~');
+tabStop.getChar();    // '~'
+```
+**Since**: 0.10.0  
+
+* * *
+
+<a name="TabStop+setChar"></a>
+
+### `tabStop.setChar(char)` ⇒ [<code>TabStop</code>](#TabStop)
+The `setChar()` method sets the delimiter character for tab stops of type `char`.
+
+If an illegal value is provided, the value will be ignored.
+
+#### Parameters
+- char <code>string</code> | <code>undefined</code>  
+The delimiter character or `undefined` to unset the delimiter character
+
+**Return value**  
+[<code>TabStop</code>](#TabStop) - The `TabStop` object
+
+**Example**  
+```js
+const tabStop = new TabStop(23, TabStopType.Char);
+tabStop.setChar('~');       // '~'
+tabStop.setChar('foo');     // '~'
+tabStop.setChar(undefined); // undefined
+```
+**Since**: 0.10.0  
+
+* * *
+
+<a name="TabStop+getLeaderColor"></a>
+
+### `tabStop.getLeaderColor()` ⇒ [<code>Color</code>](#new_Color_new) \| <code>undefined</code>
+The `getLeaderColor()` method returns the color of a leader line.
+
+**Return value**  
+[<code>Color</code>](#new_Color_new) \| <code>undefined</code> - The color of a leader line or `undefined` if the current text color will be used
+
+**Example**  
+```js
+const tabStop = new TabStop(23);
+tabStop.getLeaderColor();                           // `undefined`
+tabStop.setLeaderColor(Color.fromRgb(255, 128, 0));
+tabStop.getLeaderColor();                           // yellow color
+```
+**Since**: 0.10.0  
+
+* * *
+
+<a name="TabStop+setLeaderColor"></a>
+
+### `tabStop.setLeaderColor(color)` ⇒ [<code>TabStop</code>](#TabStop)
+The `setLeaderColor()` method sets the color of a leader line.
+
+#### Parameters
+- color [<code>Color</code>](#new_Color_new) | <code>undefined</code>  
+The color of a leader line or `undefined` if the current text color will be used
+
+**Return value**  
+[<code>TabStop</code>](#TabStop) - The `TabStop` object
+
+**Example**  
+```js
+const tabStop = new TabStop(23);
+tabStop.setLeaderColor(Color.fromRgb(255, 128, 0));
+tabStop.setLeaderColor(undefined);
+```
+**Since**: 0.10.0  
+
+* * *
+
+<a name="TabStop+getLeaderStyle"></a>
+
+### `tabStop.getLeaderStyle()` ⇒ <code>TabStopLeaderStyle</code>
+The `getLeaderStyle()` method returns the style for a leader line.
+
+**Return value**  
+<code>TabStopLeaderStyle</code> - The style for a leader line
+
+**Example**  
+```js
+const tabStop = new TabStop(23);
+tabStop.getLeaderStyle();                          // TabStopLeaderStyle.None
+tabStop.setLeaderStyle(TabStopLeaderStyle.Dotted);
+tabStop.getLeaderStyle();                          // TabStopLeaderStyle.Dotted
+```
+**Since**: 0.10.0  
+
+* * *
+
+<a name="TabStop+setLeaderStyle"></a>
+
+### `tabStop.setLeaderStyle(leaderStyle)` ⇒ [<code>TabStop</code>](#TabStop)
+The `setLeaderStyle()` method sets the style for a leader line.
+
+#### Parameters
+- leaderStyle <code>TabStopLeaderStyle</code>  
+The style for a leader line
+
+**Return value**  
+[<code>TabStop</code>](#TabStop) - The `TabStop` object
+
+**Example**  
+```js
+const tabStop = new TabStop(23);
+tabStop.setLeaderStyle(TabStopLeaderStyle.Dotted);
+```
+**Since**: 0.10.0  
 
 * * *
 
 <a name="TabStop+getPosition"></a>
 
 ### `tabStop.getPosition()` ⇒ <code>number</code>
-Returns the position of this tab stop.
+The `getPosition` method returns the position of the tab stop which is interpreted as being relative
+to the left margin or the left indent.
 
 **Return value**  
-<code>number</code> - The position of this tab stop in millimeters
+<code>number</code> - The position of the tab stop in millimeters
 
+**Example**  
+```js
+const tabStop = new TabStop(23);
+tabStop.getPosition();   // 23
+tabStop.setPosition(42);
+tabStop.getPosition();   // 42
+```
 **Since**: 0.3.0  
 
 * * *
 
-<a name="TabStop+setType"></a>
+<a name="TabStop+setPosition"></a>
 
-### `tabStop.setType(type)`
-Sets the type of this tab stop.
+### `tabStop.setPosition(position)` ⇒ [<code>TabStop</code>](#TabStop)
+The `setPosition` method sets the position of the tab stop which is interpreted as being relative
+to the left margin or the left indent.
 
 #### Parameters
-- type <code>TabStopType</code>  
-The type of the tab stop
+- position <code>number</code>  
+The position of the tab stop in millimeters.
+If a negative value is given, the `position` will be set to `0`.
 
+**Return value**  
+[<code>TabStop</code>](#TabStop) - The `TabStop` object
+
+**Example**  
+```js
+const tabStop = new TabStop(23); // 23 mm
+tabStop.setPosition(42);         // 42 mm
+tabStop.setPosition(-7);         // 0 mm
+```
 **Since**: 0.3.0  
 
 * * *
@@ -1797,11 +1819,39 @@ The type of the tab stop
 <a name="TabStop+getType"></a>
 
 ### `tabStop.getType()` ⇒ <code>TabStopType</code>
-Returns the type of this tab stop.
+The `getType` method returns the type of the tab stop.
 
 **Return value**  
-<code>TabStopType</code> - The type of this tab stop
+<code>TabStopType</code> - The type of the tab stop
 
+**Example**  
+```js
+const tabStop = new TabStop(23);
+font.getType();                   // TabStopType.Left
+font.setType(TabStopType.Center);
+font.getType();                   // TabStopType.Center
+```
+**Since**: 0.3.0  
+
+* * *
+
+<a name="TabStop+setType"></a>
+
+### `tabStop.setType(type)` ⇒ [<code>TabStop</code>](#TabStop)
+The `setType` method sets the type of the tab stop.
+
+#### Parameters
+- type <code>TabStopType</code>  
+The type of the tab stop
+
+**Return value**  
+[<code>TabStop</code>](#TabStop) - The `TabStop` object
+
+**Example**  
+```js
+const tabStop = new TabStop(23);     // TabStopType.Left
+tabStop.setType(TabStopType.Center); // TabStopType.Center
+```
 **Since**: 0.3.0  
 
 * * *
@@ -1847,13 +1897,9 @@ The level of the heading, starting with `1`; defaults to `1` if omitted
 
 **Example**  
 ```js
-document.getBody().addHeading('First Headline', 1);
-```
-**Example**  
-```js
-document.getBody().addHeading()
-  .setText('Second Headline')
-  .setLevel(2);
+new Heading('First Headline', 1);
+new Heading('First Headline');
+new Heading();
 ```
 
 * * *
@@ -1892,6 +1938,7 @@ The `getLevel()` method returns the level of the heading.
 ### `heading.addText(text)` ⇒ [<code>Paragraph</code>](#Paragraph)
 Appends the specified text to the end of the paragraph.
 
+**Overrides**: [<code>addText</code>](#Paragraph+addText)  
 #### Parameters
 - text <code>string</code>  
 The additional text content
@@ -1914,6 +1961,7 @@ new Paragraph('Some text')      // Some text
 Returns the text content of the paragraph.
 Note: This will only return the text; other elements and markup will be omitted.
 
+**Overrides**: [<code>getText</code>](#Paragraph+getText)  
 **Return value**  
 <code>string</code> - The text content of the paragraph
 
@@ -1934,6 +1982,7 @@ paragraph.getText(); // Some text, some linked text, even more text
 Sets the text content of the paragraph.
 Note: This will replace any existing content of the paragraph.
 
+**Overrides**: [<code>setText</code>](#Paragraph+setText)  
 #### Parameters
 - text <code>string</code>  
 The new text content
@@ -1955,6 +2004,7 @@ new Paragraph('Some text')     // Some text
 ### `heading.addHyperlink(text, uri)` ⇒ [<code>Hyperlink</code>](#Hyperlink)
 Appends the specified text as hyperlink to the end of the paragraph.
 
+**Overrides**: [<code>addHyperlink</code>](#Paragraph+addHyperlink)  
 #### Parameters
 - text <code>string</code>  
 The text content of the hyperlink
@@ -1979,6 +2029,7 @@ new Paragraph('Some text, ')         // Some text,
 Appends the image of the denoted path to the end of the paragraph.
 The current paragraph will be set as anchor for the image.
 
+**Overrides**: [<code>addImage</code>](#Paragraph+addImage)  
 #### Parameters
 - path <code>string</code>  
 The path to the image file
@@ -2003,6 +2054,7 @@ To reset the style, `undefined` must be given.
 
 If style and style name are both set, the custom style will be set and the common style will be ignored.
 
+**Overrides**: [<code>setStyle</code>](#Paragraph+setStyle)  
 #### Parameters
 - style <code>ParagraphStyle</code> | <code>undefined</code>  
 The new style or `undefined` to reset the style
@@ -2024,6 +2076,7 @@ new Paragraph('Some text')
 ### `heading.getStyle()` ⇒ <code>ParagraphStyle</code> \| <code>undefined</code>
 Returns the style of the paragraph.
 
+**Overrides**: [<code>getStyle</code>](#Paragraph+getStyle)  
 **Return value**  
 <code>ParagraphStyle</code> \| <code>undefined</code> - The style of the paragraph or `undefined` if no style was set
 
@@ -2046,6 +2099,7 @@ To reset the common style, `undefined` must be given.
 
 If style and style name are both set, the custom style will be set and the common style will be ignored.
 
+**Overrides**: [<code>setStyleName</code>](#Paragraph+setStyleName)  
 #### Parameters
 - styleName <code>string</code> | <code>undefined</code>  
 The name of the common style or `undefined` to reset the common style
@@ -2067,6 +2121,7 @@ new Paragraph('Some text')
 ### `heading.getStyleName()` ⇒ <code>string</code> \| <code>undefined</code>
 Returns the name of the common style of the paragraph.
 
+**Overrides**: [<code>getStyleName</code>](#Paragraph+getStyleName)  
 **Return value**  
 <code>string</code> \| <code>undefined</code> - The name of the common style or `undefined` if no common style was set
 
@@ -2109,9 +2164,7 @@ The target URI of the hyperlink
 
 **Example**  
 ```js
-document.getBody()
-  .addParagraph('This is a ')
-  .addHyperlink('link', 'https://example.com/');
+new Hyperlink('My website', 'https://example.com/');
 ```
 
 * * *
@@ -2185,11 +2238,7 @@ Creates a `List` instance that represents a list.
 
 **Example**  
 ```js
-const list = document.getBody().addList();
-list.addItem('First item');
-list.addItem('Second item');
-list.insertItem(1, 'After first item');
-list.removeItemAt(2);
+new List();
 ```
 
 * * *
@@ -2377,9 +2426,7 @@ The text content of the list item; defaults to an empty string if omitted
 
 **Example**  
 ```js
-const list = document.getBody()
-  .addList()
-  .addItem('First item');
+new ListItem('First item');
 ```
 
 * * *
@@ -2417,9 +2464,8 @@ The text content of the paragraph; defaults to an empty string if omitted
 
 **Example**  
 ```js
-document.getBody().addParagraph('Some text')
-  .addText('\nEven more text')
-  .addImage('/home/homer/myself.png');
+new Paragraph('Some text');
+new Paragraph();
 ```
 
 * * *

--- a/src/api/office/AutomaticStyles.ts
+++ b/src/api/office/AutomaticStyles.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { Border, ParagraphStyle, Style, StyleFamily } from '../style';
+import { ParagraphStyle, Style, StyleFamily } from '../style';
 import { IStyles } from './IStyles';
 
 type IStyleInformation = {
@@ -114,24 +114,23 @@ export class AutomaticStyles implements IStyles {
       const paragraphStyle = style as ParagraphStyle;
 
       // paragraph properties
-      const backgroundColor = paragraphStyle.getBackgroundColor();
-      hash.update(backgroundColor !== undefined ? backgroundColor.toHex() : '');
-      hash.update('border-bottom' + this.getBorder(paragraphStyle.getBorderBottom()));
-      hash.update('border-left' + this.getBorder(paragraphStyle.getBorderLeft()));
-      hash.update('border-right' + this.getBorder(paragraphStyle.getBorderRight()));
-      hash.update('border-top' + this.getBorder(paragraphStyle.getBorderTop()));
+      hash.update('background-color' + paragraphStyle.getBackgroundColor());
+      hash.update('border-bottom' + paragraphStyle.getBorderBottom());
+      hash.update('border-left' + paragraphStyle.getBorderLeft());
+      hash.update('border-right' + paragraphStyle.getBorderRight());
+      hash.update('border-top' + paragraphStyle.getBorderTop());
       hash.update(paragraphStyle.getHorizontalAlignment());
       hash.update(paragraphStyle.getHorizontalAlignmentLastLine());
       hash.update(paragraphStyle.getKeepTogether() ? 'kt' : '');
       hash.update(paragraphStyle.getKeepWithNext() ? 'kwn' : '');
-      hash.update('lh' + (paragraphStyle.getLineHeight() || ''));
-      hash.update('lhal' + (paragraphStyle.getLineHeightAtLeast() || ''));
-      hash.update('ls' + (paragraphStyle.getLineSpacing() || ''));
+      hash.update('lh' + paragraphStyle.getLineHeight());
+      hash.update('lhal' + paragraphStyle.getLineHeightAtLeast());
+      hash.update('ls' + paragraphStyle.getLineSpacing());
       hash.update('margin-bottom' + paragraphStyle.getMarginBottom());
       hash.update('margin-left' + paragraphStyle.getMarginLeft());
       hash.update('margin-right' + paragraphStyle.getMarginRight());
       hash.update('margin-top' + paragraphStyle.getMarginTop());
-      hash.update('orphans' + (paragraphStyle.getOrphans() || ''));
+      hash.update('orphans' + paragraphStyle.getOrphans());
       hash.update('padding-bottom' + paragraphStyle.getPaddingBottom());
       hash.update('padding-left' + paragraphStyle.getPaddingLeft());
       hash.update('padding-right' + paragraphStyle.getPaddingRight());
@@ -139,14 +138,14 @@ export class AutomaticStyles implements IStyles {
       hash.update(paragraphStyle.getPageBreak().toString());
       hash.update('text-indent' + paragraphStyle.getTextIndent());
       hash.update(paragraphStyle.getVerticalAlignment());
-      hash.update('widows' + (paragraphStyle.getWidows() || ''));
+      hash.update('widows' + paragraphStyle.getWidows());
       paragraphStyle.getTabStops().forEach((tabStop) => {
-        hash.update(`tab${tabStop.getPosition()}${tabStop.getType()}`);
+        // tslint:disable-next-line:max-line-length
+        hash.update(`tab${tabStop.getChar()}${tabStop.getLeaderColor()}${tabStop.getLeaderStyle()}${tabStop.getPosition()}${tabStop.getType()}`);
       });
 
       // text properties
-      const color = paragraphStyle.getColor();
-      hash.update(color !== undefined ? color.toHex() : '');
+      hash.update('color' + paragraphStyle.getColor());
       hash.update(paragraphStyle.getFontName() || '');
       hash.update(paragraphStyle.getFontSize().toString());
       hash.update(paragraphStyle.getFontVariant());
@@ -155,9 +154,5 @@ export class AutomaticStyles implements IStyles {
     }
 
     return hash.digest('hex');
-  }
-
-  private getBorder (border: Border | undefined): string {
-    return border !== undefined ? border.toString() : '';
   }
 }

--- a/src/api/style/TabStop.spec.ts
+++ b/src/api/style/TabStop.spec.ts
@@ -1,20 +1,31 @@
+import { Color } from './Color';
 import { TabStop } from './TabStop';
+import { TabStopLeaderStyle } from './TabStopLeaderStyle';
 import { TabStopType } from './TabStopType';
 
 describe(TabStop.name, () => {
+  const testPosition = 23;
+  const testType = TabStopType.Center;
+
+  let tabStop: TabStop;
+
+  beforeEach(() => {
+    tabStop = new TabStop(testPosition);
+  });
+
   describe('#constructor', () => {
     it('create a new tab stop with given position and default type', () => {
-      const tabStop = new TabStop(23);
+      const tabStop = new TabStop(testPosition);
 
-      expect(tabStop.getPosition()).toBe(23);
+      expect(tabStop.getPosition()).toBe(testPosition);
       expect(tabStop.getType()).toBe(TabStopType.Left);
     });
 
     it('create a new tab stop with given position and type', () => {
-      const tabStop = new TabStop(23, TabStopType.Right);
+      const tabStop = new TabStop(testPosition, testType);
 
-      expect(tabStop.getPosition()).toBe(23);
-      expect(tabStop.getType()).toBe(TabStopType.Right);
+      expect(tabStop.getPosition()).toBe(testPosition);
+      expect(tabStop.getType()).toBe(testType);
     });
 
     it('create a new tab stop and set position to 0 if it is negative', () => {
@@ -24,61 +35,93 @@ describe(TabStop.name, () => {
     });
   });
 
-  describe('#setPosition', () => {
-    let tabStop: TabStop;
+  describe('char', () => {
+    const testCharacter = '*';
 
-    beforeEach(() => {
-      tabStop = new TabStop(23);
+    it('return undefined by default', () => {
+      expect(tabStop.getChar()).toBeUndefined();
     });
 
-    it('set the position to the given value', () => {
+    it('return previous set character', () => {
+      tabStop.setChar(testCharacter);
+
+      expect(tabStop.getChar()).toBe(testCharacter);
+    });
+
+    it('return undefined if undefined is set', () => {
+      tabStop.setChar(testCharacter);
+      tabStop.setChar(undefined);
+
+      expect(tabStop.getChar()).toBeUndefined();
+    });
+
+    it('ignore invalid input', () => {
+      tabStop.setChar(testCharacter);
+      tabStop.setChar('foo');
+
+      expect(tabStop.getChar()).toBe(testCharacter);
+    });
+  });
+
+  describe('leader color', () => {
+    const testLeaderColor = Color.fromRgb(1,2,3);
+
+    it('return undefined by default', () => {
+      expect(tabStop.getLeaderColor()).toBeUndefined();
+    });
+
+    it('return previous set leader color', () => {
+      tabStop.setLeaderColor(testLeaderColor);
+
+      expect(tabStop.getLeaderColor()).toBe(testLeaderColor);
+
+      tabStop.setLeaderColor(undefined);
+
+      expect(tabStop.getLeaderColor()).toBeUndefined();
+    });
+  });
+
+  describe('leader style', () => {
+    const testLeaderStyle = TabStopLeaderStyle.Dotted;
+
+    it('return None by default', () => {
+      expect(tabStop.getLeaderStyle()).toBe(TabStopLeaderStyle.None);
+    });
+
+    it('return previous set leader style', () => {
+      tabStop.setLeaderStyle(testLeaderStyle);
+
+      expect(tabStop.getLeaderStyle()).toBe(testLeaderStyle);
+    });
+  });
+
+  describe('position', () => {
+    it('return initial position', () => {
+      expect(tabStop.getPosition()).toBe(testPosition);
+    });
+
+    it('return previous set position', () => {
       tabStop.setPosition(42);
 
       expect(tabStop.getPosition()).toBe(42);
     });
 
-    it('set the position to 0 if a negative value is given', () => {
+    it('set position to 0 if a negative value is given', () => {
       tabStop.setPosition(-42);
 
       expect(tabStop.getPosition()).toBe(0);
     });
   });
 
-  describe('#getPosition', () => {
-    let tabStop: TabStop;
-
-    beforeEach(() => {
-      tabStop = new TabStop(23);
+  describe('type', () => {
+    it('return Left by default', () => {
+      expect(tabStop.getType()).toBe(TabStopType.Left);
     });
 
-    it('return the current position', () => {
-      expect(tabStop.getPosition()).toBe(23);
-    });
-  });
+    it('return previous set type', () => {
+      tabStop.setType(testType);
 
-  describe('#setType', () => {
-    let tabStop: TabStop;
-
-    beforeEach(() => {
-      tabStop = new TabStop(23, TabStopType.Left);
-    });
-
-    it('set the type to the given value', () => {
-      tabStop.setType(TabStopType.Center);
-
-      expect(tabStop.getType()).toBe(TabStopType.Center);
-    });
-  });
-
-  describe('#getType', () => {
-    let tabStop: TabStop;
-
-    beforeEach(() => {
-      tabStop = new TabStop(23, TabStopType.Center);
-    });
-
-    it('return the current position', () => {
-      expect(tabStop.getType()).toBe(TabStopType.Center);
+      expect(tabStop.getType()).toBe(testType);
     });
   });
 });

--- a/src/api/style/TabStop.ts
+++ b/src/api/style/TabStop.ts
@@ -1,3 +1,5 @@
+import { Color } from './Color';
+import { TabStopLeaderStyle } from './TabStopLeaderStyle';
 import { TabStopType } from './TabStopType';
 
 /**
@@ -7,40 +9,155 @@ import { TabStopType } from './TabStopType';
  * To become effective they must be set to the style of the respective paragraph.
  *
  * @example
- * // creates a right aligned tab stop with a distance of 40 mm from the left margin
- * const tabStop40 = new TabStop(40, TabStopType.Right);
- * paragraph.getStyle().addTabStop(tabStop40);
+ * const tabStop = new TabStop(40)
+ *   .setLeaderColor(Color.fromRgb(1, 2, 3))
+ *   .setLeaderStyle(TabStopLeaderStyle.Dotted);
+ *
+ * @example
+ * const tabStop = new TabStop(40, TabStopType.Char)
+ *   .setChar('~');
  *
  * @since 0.3.0
  */
 export class TabStop {
+  private char: string | undefined;
+  private leaderColor: Color | undefined;
+  private leaderStyle: TabStopLeaderStyle;
+
   /**
-   * Creates a tab stop to be set to the style of a paragraph.
+   * Creates a `TabStop` instance that represents the settings of a tab stop.
    *
-   * @param {number} [position] The position of the tab stop in millimeters relative to the left margin.
+   * @example
+   * const tabStop = new TabStop(23);                     // 23mm, TabStopType.Left
+   * const tabStop = new TabStop(23, TabStopType.Center); // 23mm, TabStopType.Center
+   *
+   * @param {number} position The position of the tab stop in millimeters relative to the left margin.
    * If a negative value is given, the `position` will be set to `0`.
-   * @param {TabStopType} [type] The type of the tab stop. Defaults to `TabStopType.Left`.
+   * @param {TabStopType} [type=TabStopType.Left] The type of the tab stop
    * @since 0.3.0
    */
   public constructor (private position: number, private type = TabStopType.Left) {
     this.setPosition(position);
+    this.leaderStyle = TabStopLeaderStyle.None;
   }
 
   /**
-   * Sets the position of this tab stop.
+   * The `getChar()` method returns delimiter character for tab stops of type `char`.
    *
-   * @param {number} position The position of the tab stop in millimeters relative to the left margin.
-   * If a negative value is given, the `position` will be set to `0`.
-   * @since 0.3.0
+   * @example
+   * const tabStop = new TabStop(23, TabStopType.Char);
+   * tabStop.getChar();    // undefined
+   * tabStop.setChar('~');
+   * tabStop.getChar();    // '~'
+   *
+   * @returns {string | undefined} The delimiter character or `undefined` if the delimiter character is not set
+   * @since 0.10.0
    */
-  public setPosition (position: number): void {
-    this.position = Math.max(position, 0);
+  public getChar (): string | undefined {
+    return this.char;
   }
 
   /**
-   * Returns the position of this tab stop.
+   * The `setChar()` method sets the delimiter character for tab stops of type `char`.
    *
-   * @returns {number} The position of this tab stop in millimeters
+   * If an illegal value is provided, the value will be ignored.
+   *
+   * @example
+   * const tabStop = new TabStop(23, TabStopType.Char);
+   * tabStop.setChar('~');       // '~'
+   * tabStop.setChar('foo');     // '~'
+   * tabStop.setChar(undefined); // undefined
+   *
+   * @param {string | undefined} char The delimiter character or `undefined` to unset the delimiter character
+   * @returns {TabStop} The `TabStop` object
+   * @since 0.10.0
+   */
+  public setChar (char: string | undefined): TabStop {
+    if (char === undefined || char.length === 1) {
+      this.char = char;
+    }
+
+    return this;
+  }
+
+  /**
+   * The `getLeaderColor()` method returns the color of a leader line.
+   *
+   * @example
+   * const tabStop = new TabStop(23);
+   * tabStop.getLeaderColor();                           // `undefined`
+   * tabStop.setLeaderColor(Color.fromRgb(255, 128, 0));
+   * tabStop.getLeaderColor();                           // yellow color
+   *
+   * @returns {Color | undefined} The color of a leader line or `undefined` if the current text color will be used
+   * @since 0.10.0
+   */
+  public getLeaderColor (): Color | undefined {
+    return this.leaderColor;
+  }
+
+  /**
+   * The `setLeaderColor()` method sets the color of a leader line.
+   *
+   * @example
+   * const tabStop = new TabStop(23);
+   * tabStop.setLeaderColor(Color.fromRgb(255, 128, 0));
+   * tabStop.setLeaderColor(undefined);
+   *
+   * @param {Color | undefined} color The color of a leader line or `undefined` if the current text color will be used
+   * @returns {TabStop} The `TabStop` object
+   * @since 0.10.0
+   */
+  public setLeaderColor (color: Color | undefined): TabStop {
+    this.leaderColor = color;
+
+    return this;
+  }
+
+  /**
+   * The `getLeaderStyle()` method returns the style for a leader line.
+   *
+   * @example
+   * const tabStop = new TabStop(23);
+   * tabStop.getLeaderStyle();                          // TabStopLeaderStyle.None
+   * tabStop.setLeaderStyle(TabStopLeaderStyle.Dotted);
+   * tabStop.getLeaderStyle();                          // TabStopLeaderStyle.Dotted
+   *
+   * @returns {TabStopLeaderStyle} The style for a leader line
+   * @since 0.10.0
+   */
+  public getLeaderStyle (): TabStopLeaderStyle {
+    return this.leaderStyle;
+  }
+
+  /**
+   * The `setLeaderStyle()` method sets the style for a leader line.
+   *
+   * @example
+   * const tabStop = new TabStop(23);
+   * tabStop.setLeaderStyle(TabStopLeaderStyle.Dotted);
+   *
+   * @param {TabStopLeaderStyle} leaderStyle The style for a leader line
+   * @returns {TabStop} The `TabStop` object
+   * @since 0.10.0
+   */
+  public setLeaderStyle (leaderStyle: TabStopLeaderStyle): TabStop {
+    this.leaderStyle = leaderStyle;
+
+    return this;
+  }
+
+  /**
+   * The `getPosition` method returns the position of the tab stop which is interpreted as being relative
+   * to the left margin or the left indent.
+   *
+   * @example
+   * const tabStop = new TabStop(23);
+   * tabStop.getPosition();   // 23
+   * tabStop.setPosition(42);
+   * tabStop.getPosition();   // 42
+   *
+   * @returns {number} The position of the tab stop in millimeters
    * @since 0.3.0
    */
   public getPosition (): number {
@@ -48,22 +165,55 @@ export class TabStop {
   }
 
   /**
-   * Sets the type of this tab stop.
+   * The `setPosition` method sets the position of the tab stop which is interpreted as being relative
+   * to the left margin or the left indent.
    *
-   * @param {TabStopType} type The type of the tab stop
+   * @example
+   * const tabStop = new TabStop(23); // 23 mm
+   * tabStop.setPosition(42);         // 42 mm
+   * tabStop.setPosition(-7);         // 0 mm
+   *
+   * @param {number} position The position of the tab stop in millimeters.
+   * If a negative value is given, the `position` will be set to `0`.
+   * @returns {TabStop} The `TabStop` object
    * @since 0.3.0
    */
-  public setType (type: TabStopType): void {
-    this.type = type;
+  public setPosition (position: number): TabStop {
+    this.position = Math.max(position, 0);
+
+    return this;
   }
 
   /**
-   * Returns the type of this tab stop.
+   * The `getType` method returns the type of the tab stop.
    *
-   * @returns {TabStopType} The type of this tab stop
+   * @example
+   * const tabStop = new TabStop(23);
+   * font.getType();                   // TabStopType.Left
+   * font.setType(TabStopType.Center);
+   * font.getType();                   // TabStopType.Center
+   *
+   * @returns {TabStopType} The type of the tab stop
    * @since 0.3.0
    */
   public getType (): TabStopType {
     return this.type;
+  }
+
+  /**
+   * The `setType` method sets the type of the tab stop.
+   *
+   * @example
+   * const tabStop = new TabStop(23);     // TabStopType.Left
+   * tabStop.setType(TabStopType.Center); // TabStopType.Center
+   *
+   * @param {TabStopType} type The type of the tab stop
+   * @returns {TabStop} The `TabStop` object
+   * @since 0.3.0
+   */
+  public setType (type: TabStopType): TabStop {
+    this.type = type;
+
+    return this;
   }
 }

--- a/src/api/style/TabStopLeaderStyle.ts
+++ b/src/api/style/TabStopLeaderStyle.ts
@@ -1,0 +1,18 @@
+export enum TabStopLeaderStyle {
+  /** tab stop has no leader line */
+  None = 'none',
+  /** tab stop has a dashed leader line */
+  Dash = 'dash',
+  /** tab stop has a leader line whose repeating pattern is a dot followed by a dash */
+  DotDash = 'dot-dash',
+  /** tab stop has a leader line whose repeating pattern has two dots followed by a dash */
+  DotDotDash = 'dot-dot-dash',
+  /** tab stop has a dotted leader line */
+  Dotted = 'dotted',
+  /** tab stop has a dashed leader line whose dashes are longer than the ones from the dashed line for value dash */
+  LongDash = 'long-dash',
+  /** tab stop has a solid leader line */
+  Solid = 'solid',
+  /** tab stop has a wavy leader line */
+  Wave = 'wave'
+}

--- a/src/api/style/index.ts
+++ b/src/api/style/index.ts
@@ -13,6 +13,7 @@ export { ParagraphStyle } from './ParagraphStyle';
 export { Style } from './Style';
 export { StyleFamily } from './StyleFamily';
 export { TabStop } from './TabStop';
+export { TabStopLeaderStyle } from './TabStopLeaderStyle';
 export { TabStopType } from './TabStopType';
 export { TextProperties } from './TextProperties';
 export { TextTransformation } from './TextTransformation';

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export { ParagraphStyle } from './api/style/ParagraphStyle';
 export { Style } from './api/style/Style';
 export { StyleFamily } from './api/style/StyleFamily';
 export { TabStop } from './api/style/TabStop';
+export { TabStopLeaderStyle } from './api/style/TabStopLeaderStyle';
 export { TabStopType } from './api/style/TabStopType';
 export { TextTransformation } from './api/style/TextTransformation';
 export { Typeface } from './api/style/Typeface';

--- a/src/xml/OdfAttributeName.ts
+++ b/src/xml/OdfAttributeName.ts
@@ -32,8 +32,11 @@ export enum OdfAttributeName {
   OfficeMimetype = 'office:mimetype',
   OfficeVersion = 'office:version',
 
+  StyleChar = 'style:char',
   StyleFamily = 'style:family',
   StyleFontName = 'style:font-name',
+  StyleLeaderColor = 'style:leader-color',
+  StyleLeaderStyle = 'style:leader-style',
   StyleLineHeightAtLeast = 'style:line-height-at-least',
   StyleLineSpacing = 'style:line-spacing',
   StyleName = 'style:name',

--- a/src/xml/office/StylesWriter.spec.ts
+++ b/src/xml/office/StylesWriter.spec.ts
@@ -2,8 +2,8 @@
 import { DOMImplementation, XMLSerializer } from 'xmldom';
 import { CommonStyles, AutomaticStyles } from '../../api/office';
 import { BorderStyle, Color, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine } from '../../api/style';
-import { PageBreak, ParagraphStyle, TextTransformation, Typeface, TabStop, TabStopType } from '../../api/style';
-import { VerticalAlignment } from '../../api/style';
+import { PageBreak, ParagraphStyle, TabStop, TabStopLeaderStyle, TabStopType } from '../../api/style';
+import { TextTransformation, Typeface, VerticalAlignment } from '../../api/style';
 import { OdfElementName } from '../OdfElementName';
 import { StylesWriter } from './StylesWriter';
 
@@ -343,7 +343,8 @@ describe(StylesWriter.name, () => {
 
         it('set tab stop types', () => {
           testStyle.addTabStop(new TabStop(2, TabStopType.Center));
-          testStyle.addTabStop(new TabStop(4, TabStopType.Char));
+          testStyle.addTabStop(new TabStop(4, TabStopType.Char).setChar('~'));
+          testStyle.addTabStop(new TabStop(5, TabStopType.Char));
           testStyle.addTabStop(new TabStop(6, TabStopType.Left));
           testStyle.addTabStop(new TabStop(8, TabStopType.Right));
 
@@ -351,9 +352,29 @@ describe(StylesWriter.name, () => {
           const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
           expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center"\/>/);
-          expect(documentAsString).toMatch(/<style:tab-stop style:position="4mm" style:type="char"\/>/);
+          expect(documentAsString).toMatch(/<style:tab-stop style:position="4mm" style:type="char" style:char="~"\/>/);
           expect(documentAsString).toMatch(/<style:tab-stop style:position="6mm"\/>/);
           expect(documentAsString).toMatch(/<style:tab-stop style:position="8mm" style:type="right"\/>/);
+        });
+
+        it('set leader style', () => {
+          testStyle.addTabStop(new TabStop(2, TabStopType.Center).setLeaderStyle(TabStopLeaderStyle.Dotted));
+
+          stylesWriter.write(commonStyles, testDocument, testRoot);
+          const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+          // tslint:disable-next-line:max-line-length
+          expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center" style:leader-style="dotted"\/>/);
+        });
+
+        it('set leader color', () => {
+          testStyle.addTabStop(new TabStop(2, TabStopType.Center).setLeaderColor(Color.fromRgb(1, 2, 3)));
+
+          stylesWriter.write(commonStyles, testDocument, testRoot);
+          const documentAsString = new XMLSerializer().serializeToString(testDocument);
+
+          // tslint:disable-next-line:max-line-length
+          expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center" style:leader-color="#010203"\/>/);
         });
       });
     });

--- a/src/xml/office/StylesWriter.ts
+++ b/src/xml/office/StylesWriter.ts
@@ -1,8 +1,8 @@
 // tslint:disable:no-duplicate-imports
 import { AutomaticStyles, CommonStyles, IStyles } from '../../api/office';
 import { BorderStyle, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine, PageBreak } from '../../api/style';
-import { ParagraphStyle, Style, StyleFamily, TabStopType, TextTransformation, Typeface } from '../../api/style';
-import { VerticalAlignment } from '../../api/style';
+import { ParagraphStyle, Style, StyleFamily, TabStopLeaderStyle, TabStopType } from '../../api/style';
+import { TextTransformation, Typeface, VerticalAlignment } from '../../api/style';
 import { OdfAttributeName } from '../OdfAttributeName';
 import { OdfElementName } from '../OdfElementName';
 
@@ -224,8 +224,24 @@ export class StylesWriter {
       tabStopsElement.appendChild(tabStopElement);
 
       tabStopElement.setAttribute(OdfAttributeName.StylePosition, tabStop.getPosition() + 'mm');
-      if (tabStop.getType() !== TabStopType.Left) {
-        tabStopElement.setAttribute(OdfAttributeName.StyleType, tabStop.getType());
+
+      const type = tabStop.getType();
+      const char = tabStop.getChar();
+      if (type === TabStopType.Char && char !== undefined) {
+        tabStopElement.setAttribute(OdfAttributeName.StyleType, type);
+        tabStopElement.setAttribute(OdfAttributeName.StyleChar, char);
+      } else if (type !== TabStopType.Left) {
+        tabStopElement.setAttribute(OdfAttributeName.StyleType, type);
+      }
+
+      const leaderStyle = tabStop.getLeaderStyle();
+      if (leaderStyle !== TabStopLeaderStyle.None) {
+        tabStopElement.setAttribute(OdfAttributeName.StyleLeaderStyle, leaderStyle);
+      }
+
+      const leaderColor = tabStop.getLeaderColor();
+      if (leaderColor !== undefined) {
+        tabStopElement.setAttribute(OdfAttributeName.StyleLeaderColor, leaderColor.toHex());
       }
     });
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please provide a description above and answer the questions below.

Bug fixes and new features must include tests.

If this is your first contribution, don't forget to add your name to the contributors list in the package.json.
-->

**What kind of change is this PR?**

feature

**What is the current behavior?**

**What is the new behavior (if this is a feature change)?**

On the paragraph style it is now possible to configure the alignment character for tab stops of type `Char` using the new method `setChar`. Additionally the leader style of a tab stop now can be configured with the new `setLeaderStyle` and `setLeaderColor` methods.

See [style:char](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#attribute-style_char), [style:leader-color](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#attribute-style_leader-color), [style:leader-style](http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#attribute-style_leader-style) in the OASIS Document Format.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Changelog has been updated
- [x] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
