### PR TITLE
implement sublists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased] (2019-??-??)
+### Added
+- **list:** implement sublists
+
 ### Changed
 - **list:** text content of a list item cannot be styled, closes [#67](https://github.com/connium/simple-odf/issues/67)
 

--- a/src/api/text/ListItem.spec.ts
+++ b/src/api/text/ListItem.spec.ts
@@ -1,4 +1,5 @@
 import { Heading } from './Heading';
+import { List } from './List';
 import { ListItem } from './ListItem';
 import { Paragraph } from './Paragraph';
 
@@ -14,6 +15,14 @@ describe(ListItem.name, () => {
       const heading = listItem.addHeading();
 
       expect(heading).toBeInstanceOf(Heading);
+    });
+  });
+
+  describe('#addList', () => {
+    it('return a list', () => {
+      const list = listItem.addList();
+
+      expect(list).toBeInstanceOf(List);
     });
   });
 

--- a/src/api/text/ListItem.ts
+++ b/src/api/text/ListItem.ts
@@ -1,5 +1,6 @@
 import { OdfElement } from '../OdfElement';
 import { Heading } from './Heading';
+import { List } from './List';
 import { Paragraph } from './Paragraph';
 
 /**
@@ -9,6 +10,7 @@ import { Paragraph } from './Paragraph';
  * const listItem = new ListItem();
  * listItem.addHeading('headline');
  * listItem.addParagraph('paragraph');
+ * const subList = listItem.addList();
  *
  * @since 0.2.0
  */
@@ -39,6 +41,23 @@ export class ListItem extends OdfElement {
     this.append(heading);
 
     return heading;
+  }
+
+  /**
+   * Adds an empty list at the end of the list item.
+   *
+   * @example
+   * new ListItem()
+   *   .addList();
+   *
+   * @returns {List} The newly added list
+   * @since 0.11.0
+   */
+  public addList (): List {
+    const list = new List();
+    this.append(list);
+
+    return list;
   }
 
   /**

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -10,7 +10,7 @@ import { TextTransformation, Typeface, VerticalAlignment } from '../src/api/styl
 
 const FILEPATH = './integration.fodt';
 
-describe('integration', () => {
+xdescribe('integration', () => {
   let document: TextDocument;
   let body: TextBody;
 

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -10,7 +10,7 @@ import { TextTransformation, Typeface, VerticalAlignment } from '../src/api/styl
 
 const FILEPATH = './integration.fodt';
 
-xdescribe('integration', () => {
+describe('integration', () => {
   let document: TextDocument;
   let body: TextBody;
 
@@ -303,6 +303,11 @@ xdescribe('integration', () => {
     list.addItem().addHeading('list item heading', 3);
     list.addItem().addParagraph('first item');
     list.addItem().addParagraph('second item');
+
+    const sublist = list.addItem().addList();
+    sublist.addItem().addHeading('sublist item heading', 3);
+    sublist.addItem().addParagraph('first subitem');
+    sublist.addItem().addParagraph('second subitem');
   });
 
   it('save document', async (done) => {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please provide a description above and answer the questions below.

Bug fixes and new features must include tests.

If this is your first contribution, don't forget to add your name to the contributors list in the package.json.
-->

**What kind of change is this PR?**

feature

**What is the current behavior?**

A `ListItem` accepts one or multiple headings and paragraphs but it is not possible to add a list for creating sublists.

**What is the new behavior (if this is a feature change)?**

It is possible to add a `List` to a `ListItem` via the new `addList` method.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Changelog has been updated
- [x] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
