### PR TITLE
use standardx for linting, fix linting errors, remove tslint annotations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,16 +1,14 @@
 {
-  "parser": "@typescript-eslint/parser",
-  "extends": [
-    "plugin:@typescript-eslint/recommended"
-  ],
-  "plugins": [
-    "@typescript-eslint"
-  ],
   "rules": {
     "semi": ["error", "always"],
-    "max-len": ["error", {
-      "code": 120,
-      "tabWidth": 2
-    }]
+    "max-len": ["error", { "code": 120, "ignoreRegExpLiterals": true }],
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error",
+    "no-useless-constructor": "off",
+    "@typescript-eslint/no-useless-constructor": "error"
+  },
+  "env": {
+    "jest": true,
+    "node": true
   }
 }

--- a/.npmignore
+++ b/.npmignore
@@ -9,7 +9,7 @@ test/
 tools/
 
 .bettercodehub.yml
+.eslintrc.json
 .travis.yml
 TODO.md
 tsconfig.json
-tslint.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] (2019-??-??)
-### Changed
-- **chore(lint):** replace tslint with eslint
-
-## [Unreleased] (2019-??-??)
 ### Added
 - **list:** implement sublists
 
 ### Changed
 - **list:** text content of a list item cannot be styled, closes [#67](https://github.com/connium/simple-odf/issues/67)
+- **chore(lint):** replace tslint with eslint
 
 ## [0.10.1] (2019-07-11)
 ### Changed

--- a/examples/homer-resume/index.ts
+++ b/examples/homer-resume/index.ts
@@ -93,7 +93,6 @@ body.addHeading('Nuclear Safety Inspector', 3)
 body.addParagraph('Springfield Nuclear Power Plant, Springfield, USA')
   .setStyle(companyNameStyle);
 const list1 = body.addList();
-// tslint:disable-next-line:max-line-length
 list1.addItem().addParagraph('Strengthened safety procedures that resulted in 75% fewer accidents on days I was absent');
 list1.addItem().addParagraph('Pioneered workplace stress-reduction methods that worked for at least one employee');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -560,17 +560,6 @@
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^2.0.1",
         "tsutils": "^3.17.1"
-      },
-      "dependencies": {
-        "tsutils": {
-          "version": "3.17.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -770,6 +759,16 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
     },
     "array-unique": {
       "version": "0.3.2",
@@ -1354,6 +1353,12 @@
         }
       }
     },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -1445,6 +1450,12 @@
         "ms": "2.0.0"
       }
     },
+    "debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "dev": true
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -1519,6 +1530,28 @@
         }
       }
     },
+    "deglob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
+      "dev": true,
+      "requires": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^5.0.0",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1563,6 +1596,15 @@
           "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
           "dev": true
         }
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
       }
     },
     "domexception": {
@@ -1667,9 +1709,9 @@
       }
     },
     "eslint": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
-      "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
+      "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1720,15 +1762,6 @@
             "ms": "^2.1.1"
           }
         },
-        "doctrine": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1742,6 +1775,336 @@
           "dev": true
         }
       }
+    },
+    "eslint-config-standard": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
+      "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
+      "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.4.2",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
+      "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^2.0.0",
+        "eslint-utils": "^1.4.2",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-plugin-standard": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+      "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.0.0",
@@ -2114,6 +2477,12 @@
         }
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -2215,8 +2584,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2237,14 +2605,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2259,20 +2625,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2389,8 +2752,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2402,7 +2764,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2417,7 +2778,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2425,14 +2785,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2451,7 +2809,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2532,8 +2889,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2545,7 +2901,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2631,8 +2986,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2668,7 +3022,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2688,7 +3041,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2732,14 +3084,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2759,6 +3109,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "dev": true
     },
     "get-stream": {
@@ -4005,6 +4361,16 @@
         "verror": "1.10.0"
       }
     },
+    "jsx-ast-utils": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
+      }
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -4445,6 +4811,12 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -4482,6 +4854,12 @@
       "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
       "dev": true
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -4503,6 +4881,62 @@
         "isobject": "^3.0.0"
       }
     },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
+      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.15.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
+      }
+    },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
@@ -4520,6 +4954,18 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "once": {
@@ -4708,6 +5154,48 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -4761,6 +5249,17 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.3"
+      }
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "psl": {
@@ -5089,6 +5588,12 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "rxjs": {
       "version": "6.5.3",
@@ -5476,6 +5981,53 @@
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
     },
+    "standard": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-14.3.1.tgz",
+      "integrity": "sha512-TUQwU7znlZLfgKH1Zwn/D84FitWZkUTfbxSiz/vFx+4c9GV+clSfG/qLiLZOlcdyzhw3oF5/pZydNjbNDfHPEw==",
+      "dev": true,
+      "requires": {
+        "eslint": "~6.4.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-config-standard-jsx": "8.1.0",
+        "eslint-plugin-import": "~2.18.0",
+        "eslint-plugin-node": "~10.0.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.14.2",
+        "eslint-plugin-standard": "~4.0.0",
+        "standard-engine": "^12.0.0"
+      }
+    },
+    "standard-engine": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.0.tgz",
+      "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
+      "dev": true,
+      "requires": {
+        "deglob": "^4.0.0",
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.1.0",
+        "pkg-conf": "^3.1.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "standardx": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/standardx/-/standardx-5.0.0.tgz",
+      "integrity": "sha512-dWbhU91EqwwWTED224B4X0h1q01Tv2wIv30mFz4NOQ+JMEJKtCrBOUEgMpBIynSFm6MDJYr+H7xUPVMYjGd8HA==",
+      "dev": true,
+      "requires": {
+        "standard": "^14.0.0",
+        "standard-engine": "^12.0.0"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -5565,6 +6117,26 @@
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^5.1.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "strip-ansi": {
@@ -5832,10 +6404,19 @@
       }
     },
     "tslib": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -5860,6 +6441,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true
     },
     "typescript": {
       "version": "3.5.3",
@@ -5916,6 +6503,12 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -6170,6 +6763,12 @@
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "jest",
     "watch-test": "jest --watch",
     "coverage": "jest --coverage",
-    "lint": "eslint ./**/*.ts",
+    "lint": "standardx \"src/**/*.ts\"  \"test/**/*.ts\"",
     "docs": "rm -r ./lib && tsc && jsdoc2md --name-format --param-list-format list --separators --partial ./tools/jsdoc2md/body.hbs ./tools/jsdoc2md/params-list.hbs ./tools/jsdoc2md/returns.hbs ./tools/jsdoc2md/scope.hbs --files ./lib/api/**/*.js > ./docs/API.md"
   },
   "dependencies": {
@@ -49,9 +49,9 @@
     "@types/xmldom": "^0.1.29",
     "@typescript-eslint/eslint-plugin": "^2.3.3",
     "@typescript-eslint/parser": "^2.3.3",
-    "eslint": "^6.5.1",
     "jest": "^24.1.0",
     "jsdoc-to-markdown": "^5.0.0",
+    "standardx": "^5.0.0",
     "ts-jest": "^24.0.2",
     "typescript": "^3.3.3"
   },
@@ -68,5 +68,11 @@
       "js"
     ],
     "collectCoverage": true
+  },
+  "standardx": {
+    "parser": "@typescript-eslint/parser",
+    "plugins": [
+      "@typescript-eslint/eslint-plugin"
+    ]
   }
 }

--- a/src/api/meta/Meta.ts
+++ b/src/api/meta/Meta.ts
@@ -73,7 +73,6 @@ export class Meta {
    * @since 0.6.0
    */
   public setCreator (creator: string | undefined): Meta {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (creator === undefined || typeof creator === 'string') {
       this.creator = creator;
     }
@@ -163,7 +162,6 @@ export class Meta {
    * @since 0.6.0
    */
   public setDescription (description: string | undefined): Meta {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (description === undefined || typeof description === 'string') {
       this.description = description;
     }
@@ -235,7 +233,6 @@ export class Meta {
    * @since 0.6.0
    */
   public setInitialCreator (initialCreator: string | undefined): Meta {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (initialCreator === undefined || typeof initialCreator === 'string') {
       this.initialCreator = initialCreator;
     }
@@ -274,7 +271,6 @@ export class Meta {
    * @since 0.6.0
    */
   public addKeyword (keyword: string): Meta {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (typeof keyword === 'string') {
       this.keywords.push(...keyword.split(','));
     }
@@ -424,7 +420,6 @@ export class Meta {
    * @since 0.6.0
    */
   public setPrintedBy (printedBy: string | undefined): Meta {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (printedBy === undefined || typeof printedBy === 'string') {
       this.printedBy = printedBy;
     }
@@ -462,7 +457,6 @@ export class Meta {
    * @since 0.6.0
    */
   public setSubject (subject: string | undefined): Meta {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (subject === undefined || typeof subject === 'string') {
       this.subject = subject;
     }
@@ -499,7 +493,6 @@ export class Meta {
    * @since 0.6.0
    */
   public setTitle (title: string | undefined): Meta {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (title === undefined || typeof title === 'string') {
       this.title = title;
     }

--- a/src/api/office/AutomaticStyles.spec.ts
+++ b/src/api/office/AutomaticStyles.spec.ts
@@ -41,7 +41,7 @@ describe(AutomaticStyles.name, () => {
       automaticStyles.add(testStyle1);
 
       expect(() => {
-        automaticStyles.getName(testStyle2)
+        automaticStyles.getName(testStyle2);
       }).toThrow();
     });
   });

--- a/src/api/office/AutomaticStyles.ts
+++ b/src/api/office/AutomaticStyles.ts
@@ -140,8 +140,7 @@ export class AutomaticStyles implements IStyles {
       hash.update(paragraphStyle.getVerticalAlignment());
       hash.update('widows' + paragraphStyle.getWidows());
       paragraphStyle.getTabStops().forEach((tabStop) => {
-        // tslint:disable-next-line:max-line-length
-        hash.update(`tab${tabStop.getChar()}${tabStop.getLeaderColor()}${tabStop.getLeaderStyle()}${tabStop.getPosition()}${tabStop.getType()}`);
+        hash.update(`tab${tabStop.getChar()}${tabStop.getLeaderColor()}${tabStop.getLeaderStyle()}${tabStop.getPosition()}${tabStop.getType()}`); // eslint-disable-line max-len
       });
 
       // text properties

--- a/src/api/style/FontFace.ts
+++ b/src/api/style/FontFace.ts
@@ -58,7 +58,7 @@ export class FontFace {
    * @since 0.8.0
    */
   public setCharset (fontCharset: string | undefined): FontFace {
-    if (fontCharset === undefined || /^[A-Za-z][A-Za-z0-9._\-]*$/.test(fontCharset) === true) {
+    if (fontCharset === undefined || /^[A-Za-z][A-Za-z0-9._-]*$/.test(fontCharset) === true) {
       this.fontCharset = fontCharset;
     }
 
@@ -94,7 +94,6 @@ export class FontFace {
    * @since 0.8.0
    */
   public setFontFamily (fontFamily: string | undefined): FontFace {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (fontFamily === undefined || typeof fontFamily === 'string') {
       this.fontFamily = fontFamily;
     }
@@ -131,7 +130,6 @@ export class FontFace {
    * @since 0.8.0
    */
   public setFontFamilyGeneric (fontFamilyGeneric: FontFamilyGeneric | undefined): FontFace {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (fontFamilyGeneric === undefined || typeof fontFamilyGeneric === 'string') {
       this.fontFamilyGeneric = fontFamilyGeneric;
     }

--- a/src/api/style/ParagraphProperties.ts
+++ b/src/api/style/ParagraphProperties.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-dupe-class-members */
 import { isNonNegativeNumber, isPercent } from '../util';
 import { Border } from './Border';
 import { BorderStyle } from './BorderStyle';

--- a/src/api/style/ParagraphStyle.ts
+++ b/src/api/style/ParagraphStyle.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-dupe-class-members */
 import { Border } from './Border';
 import { BorderStyle } from './BorderStyle';
 import { Color } from './Color';

--- a/src/api/style/Style.ts
+++ b/src/api/style/Style.ts
@@ -52,7 +52,6 @@ export class Style {
    * @since 0.9.0
    */
   public setClass (clazz: string | undefined): Style {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (clazz === undefined || typeof clazz === 'string') {
       this.clazz = clazz;
     }

--- a/src/api/style/TabStop.spec.ts
+++ b/src/api/style/TabStop.spec.ts
@@ -64,7 +64,7 @@ describe(TabStop.name, () => {
   });
 
   describe('leader color', () => {
-    const testLeaderColor = Color.fromRgb(1,2,3);
+    const testLeaderColor = Color.fromRgb(1, 2, 3);
 
     it('return undefined by default', () => {
       expect(tabStop.getLeaderColor()).toBeUndefined();

--- a/src/api/text/Hyperlink.ts
+++ b/src/api/text/Hyperlink.ts
@@ -39,7 +39,6 @@ export class Hyperlink extends OdfTextElement {
    * @since 0.3.0
    */
   public setURI (uri: string): Hyperlink {
-    /* tslint:disable-next-line:strict-type-predicates */
     if (typeof uri === 'string' && uri.trim().length > 0) {
       this.uri = uri;
     }

--- a/src/xml/DomVisitor.spec.ts
+++ b/src/xml/DomVisitor.spec.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:max-line-length */
 import { join } from 'path';
 import { DOMImplementation, XMLSerializer } from 'xmldom';
 import { Image, AnchorType } from '../api/draw';
@@ -186,7 +185,6 @@ describe(DomVisitor.name, () => {
         domVisitor.visit(paragraph, testDocument, testRoot);
 
         const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        /* tslint:disable-next-line:max-line-length */
         expect(documentAsString).toMatch(/<text:p> some <text:s\/>spacey <text:s c="2"\/>text <text:s c="3"\/><\/text:p>/);
       });
 

--- a/src/xml/OdfTextElementWriter.ts
+++ b/src/xml/OdfTextElementWriter.ts
@@ -10,7 +10,6 @@ export class OdfTextElementWriter {
    */
   public write (odfText: OdfTextElement, document: Document, parent: Element): void {
     const text = odfText.getText();
-    /* tslint:disable-next-line:strict-type-predicates */
     if (text === undefined || text === '') {
       return;
     }
@@ -22,7 +21,7 @@ export class OdfTextElementWriter {
         case SPACE:
           str += currentChar;
 
-          const count = this.findNextNonSpaceCharacter(text, index) - 1;
+          const count = this.findNextNonSpaceCharacter(text, index) - 1; // eslint-disable-line no-case-declarations
           if (count > 0) {
             this.appendTextNode(document, parent, str);
             this.appendSpaceNode(document, parent, count);

--- a/src/xml/meta/MetaWriter.spec.ts
+++ b/src/xml/meta/MetaWriter.spec.ts
@@ -23,12 +23,12 @@ describe(MetaWriter.name, () => {
       metaWriter.write(testDocument, testRoot, meta);
 
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
-      const regex = new RegExp('<office:meta>'
-        + '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>'
-        + '<meta:initial-creator>' + userInfo().username + '</meta:initial-creator>'
-        + '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>'
-        + '<meta:editing-cycles>1</meta:editing-cycles>'
-        + '</office:meta>');
+      const regex = new RegExp('<office:meta>' +
+        '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>' +
+        '<meta:initial-creator>' + userInfo().username + '</meta:initial-creator>' +
+        '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>' +
+        '<meta:editing-cycles>1</meta:editing-cycles>' +
+        '</office:meta>');
       expect(documentAsString).toMatch(regex);
     });
 
@@ -44,11 +44,11 @@ describe(MetaWriter.name, () => {
       metaWriter.write(testDocument, testRoot, meta);
 
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
-      const regex = new RegExp('<office:meta>'
-        + '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>'
-        + '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>'
-        + '<meta:editing-cycles>1</meta:editing-cycles>'
-        + '</office:meta>');
+      const regex = new RegExp('<office:meta>' +
+        '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>' +
+        '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>' +
+        '<meta:editing-cycles>1</meta:editing-cycles>' +
+        '</office:meta>');
       expect(documentAsString).toMatch(regex);
     });
 
@@ -63,28 +63,27 @@ describe(MetaWriter.name, () => {
         .setPrintDate(new Date(Date.UTC(2021, 3, 1)))
         .setPrintedBy('Maggie Simpson')
         .setSubject('some test subject')
-        .setTitle('some test title')
-        ;
+        .setTitle('some test title');
 
       metaWriter.write(testDocument, testRoot, meta);
 
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
-      const regex = new RegExp('<office:meta>'
-        + '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>'
-        + '<dc:title>some test title</dc:title>'
-        + '<dc:description>some test description</dc:description>'
-        + '<dc:subject>some test subject</dc:subject>'
-        + '<meta:keyword>some keyword</meta:keyword>'
-        + '<meta:keyword>some other keyword</meta:keyword>'
-        + '<meta:initial-creator>Marge Simpson</meta:initial-creator>'
-        + '<dc:creator>Homer Simpson</dc:creator>'
-        + '<meta:printed-by>Maggie Simpson</meta:printed-by>'
-        + '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>'
-        + '<dc:date>2020-12-24T13:37:23.042Z</dc:date>'
-        + '<meta:print-date>2021-04-01T00:00:00.000Z</meta:print-date>'
-        + '<dc:language>zu</dc:language>'
-        + '<meta:editing-cycles>1</meta:editing-cycles>'
-        + '</office:meta>');
+      const regex = new RegExp('<office:meta>' +
+        '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>' +
+        '<dc:title>some test title</dc:title>' +
+        '<dc:description>some test description</dc:description>' +
+        '<dc:subject>some test subject</dc:subject>' +
+        '<meta:keyword>some keyword</meta:keyword>' +
+        '<meta:keyword>some other keyword</meta:keyword>' +
+        '<meta:initial-creator>Marge Simpson</meta:initial-creator>' +
+        '<dc:creator>Homer Simpson</dc:creator>' +
+        '<meta:printed-by>Maggie Simpson</meta:printed-by>' +
+        '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>' +
+        '<dc:date>2020-12-24T13:37:23.042Z</dc:date>' +
+        '<meta:print-date>2021-04-01T00:00:00.000Z</meta:print-date>' +
+        '<dc:language>zu</dc:language>' +
+        '<meta:editing-cycles>1</meta:editing-cycles>' +
+        '</office:meta>');
       expect(documentAsString).toMatch(regex);
     });
   });

--- a/src/xml/office/FontFaceDeclarationsWriter.spec.ts
+++ b/src/xml/office/FontFaceDeclarationsWriter.spec.ts
@@ -23,7 +23,6 @@ describe(FontFaceDeclarationsWriter.name, () => {
       fontFaceDeclarationsWriter.write(fontFaceDeclarations, testDocument, testRoot);
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-      /* tslint:disable-next-line:max-line-length */
       expect(documentAsString).not.toMatch(/office:font-face-decls/);
     });
 
@@ -33,7 +32,6 @@ describe(FontFaceDeclarationsWriter.name, () => {
       fontFaceDeclarationsWriter.write(fontFaceDeclarations, testDocument, testRoot);
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-      /* tslint:disable-next-line:max-line-length */
       expect(documentAsString).toMatch(/<office:font-face-decls><style:font-face style:name="Springfield" svg:font-family="Springfield" style:font-pitch="variable"\/><\/office:font-face-decls>/);
     });
 
@@ -43,7 +41,6 @@ describe(FontFaceDeclarationsWriter.name, () => {
       fontFaceDeclarationsWriter.write(fontFaceDeclarations, testDocument, testRoot);
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-      /* tslint:disable-next-line:max-line-length */
       expect(documentAsString).toMatch(/<office:font-face-decls><style:font-face style:name="Homer Simpson" svg:font-family="'Homer Simpson'" style:font-pitch="fixed"\/><\/office:font-face-decls>/);
     });
   });

--- a/src/xml/office/StylesWriter.spec.ts
+++ b/src/xml/office/StylesWriter.spec.ts
@@ -1,4 +1,4 @@
-// tslint:disable:no-duplicate-imports
+/* eslint-disable import/no-duplicates */
 import { DOMImplementation, XMLSerializer } from 'xmldom';
 import { CommonStyles, AutomaticStyles } from '../../api/office';
 import { BorderStyle, Color, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine } from '../../api/style';
@@ -6,6 +6,7 @@ import { PageBreak, ParagraphStyle, TabStop, TabStopLeaderStyle, TabStopType } f
 import { TextTransformation, Typeface, VerticalAlignment } from '../../api/style';
 import { OdfElementName } from '../OdfElementName';
 import { StylesWriter } from './StylesWriter';
+/* eslint-enable import/no-duplicates */
 
 describe(StylesWriter.name, () => {
   describe('#write', () => {
@@ -35,7 +36,6 @@ describe(StylesWriter.name, () => {
       stylesWriter.write(commonStyles, testDocument, testRoot);
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-      // tslint:disable-next-line:max-line-length
       expect(documentAsString).toMatch(/<office:styles><style:style style:name="Summary" style:display-name="Summary" style:family="paragraph">.*<\/style:style><\/office:styles>/);
     });
 
@@ -46,7 +46,6 @@ describe(StylesWriter.name, () => {
       stylesWriter.write(automaticStyles, testDocument, testRoot);
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-      // tslint:disable-next-line:max-line-length
       expect(documentAsString).toMatch(/<office:automatic-styles><style:style style:name="P1" style:family="paragraph">.*<\/style:style><\/office:automatic-styles>/);
     });
 
@@ -57,7 +56,6 @@ describe(StylesWriter.name, () => {
       stylesWriter.write(commonStyles, testDocument, testRoot);
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-      // tslint:disable-next-line:max-line-length
       expect(documentAsString).toMatch(/<office:styles><style:style style:name="Summary" style:display-name="Summary" style:family="paragraph" style:class="someClass">.*<\/style:style><\/office:styles>/);
     });
 
@@ -67,7 +65,6 @@ describe(StylesWriter.name, () => {
       stylesWriter.write(commonStyles, testDocument, testRoot);
       const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-      // tslint:disable-next-line:max-line-length
       expect(documentAsString).toMatch(/<office:styles><style:style style:name="Summary" style:display-name="Summary" style:family="paragraph"><style:paragraph-properties\/><style:text-properties\/><\/style:style><\/office:styles>/);
     });
 
@@ -146,7 +143,6 @@ describe(StylesWriter.name, () => {
         stylesWriter.write(commonStyles, testDocument, testRoot);
         documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-        // tslint:disable-next-line:max-line-length
         expect(documentAsString).toMatch(/<style:paragraph-properties fo:text-align="justify" fo:text-align-last="center"\/>/);
       });
 
@@ -337,7 +333,6 @@ describe(StylesWriter.name, () => {
           stylesWriter.write(commonStyles, testDocument, testRoot);
           const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-          // tslint:disable-next-line:max-line-length
           expect(documentAsString).toMatch(/<style:paragraph-properties><style:tab-stops><style:tab-stop style:position="2mm"\/><\/style:tab-stops><\/style:paragraph-properties>/);
         });
 
@@ -363,7 +358,6 @@ describe(StylesWriter.name, () => {
           stylesWriter.write(commonStyles, testDocument, testRoot);
           const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-          // tslint:disable-next-line:max-line-length
           expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center" style:leader-style="dotted"\/>/);
         });
 
@@ -373,7 +367,6 @@ describe(StylesWriter.name, () => {
           stylesWriter.write(commonStyles, testDocument, testRoot);
           const documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-          // tslint:disable-next-line:max-line-length
           expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center" style:leader-color="#010203"\/>/);
         });
       });

--- a/src/xml/office/StylesWriter.ts
+++ b/src/xml/office/StylesWriter.ts
@@ -1,10 +1,11 @@
-// tslint:disable:no-duplicate-imports
+/* eslint-disable import/no-duplicates */
 import { AutomaticStyles, CommonStyles, IStyles } from '../../api/office';
 import { BorderStyle, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine, PageBreak } from '../../api/style';
 import { ParagraphStyle, Style, StyleFamily, TabStopLeaderStyle, TabStopType } from '../../api/style';
 import { TextTransformation, Typeface, VerticalAlignment } from '../../api/style';
 import { OdfAttributeName } from '../OdfAttributeName';
 import { OdfElementName } from '../OdfElementName';
+/* eslint-enable import/no-duplicates */
 
 /**
  * Transforms a {@link StyleManager} object into ODF conform XML
@@ -99,8 +100,8 @@ export class StylesWriter {
     }
 
     const horizontalAlignmentLastLine = style.getHorizontalAlignmentLastLine();
-    if (horizontalAlignment === HorizontalAlignment.Justify
-      && horizontalAlignmentLastLine !== HorizontalAlignmentLastLine.Default) {
+    if (horizontalAlignment === HorizontalAlignment.Justify &&
+      horizontalAlignmentLastLine !== HorizontalAlignmentLastLine.Default) {
       paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatTextAlignLast, horizontalAlignmentLastLine);
     }
 
@@ -286,9 +287,7 @@ export class StylesWriter {
       textPropertiesElement.setAttribute(OdfAttributeName.FormatFontStyle, 'oblique');
     }
 
-    if (typeface === Typeface.Bold
-      || typeface === Typeface.BoldItalic
-      || typeface === Typeface.BoldOblique) {
+    if (typeface === Typeface.Bold || typeface === Typeface.BoldItalic || typeface === Typeface.BoldOblique) {
       textPropertiesElement.setAttribute(OdfAttributeName.FormatFontWeight, 'bold');
     }
 

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -1,4 +1,4 @@
-// tslint:disable:no-duplicate-imports
+/* eslint-disable import/no-duplicates */
 import { unlink } from 'fs';
 import { join } from 'path';
 import { promisify } from 'util';
@@ -7,6 +7,7 @@ import { TextBody, TextDocument } from '../src/api/office';
 import { BorderStyle, Color, FontPitch, FontVariant, HorizontalAlignment } from '../src/api/style';
 import { HorizontalAlignmentLastLine, PageBreak, ParagraphStyle, TabStop, TabStopType } from '../src/api/style';
 import { TextTransformation, Typeface, VerticalAlignment } from '../src/api/style';
+/* eslint-enable import/no-duplicates */
 
 const FILEPATH = './integration.fodt';
 
@@ -99,8 +100,8 @@ xdescribe('integration', () => {
       style.setHorizontalAlignment(HorizontalAlignment.Justify);
       style.setHorizontalAlignmentLastLine(HorizontalAlignmentLastLine.Center);
 
-      const paragraph = body.addParagraph('Some justified text'
-        + ' (with a lot of text to make sure it does not fit into a single line) with a centered last line');
+      const paragraph = body.addParagraph('Some justified text' +
+        ' (with a lot of text to make sure it does not fit into a single line) with a centered last line');
       paragraph.setStyle(style);
     });
 


### PR DESCRIPTION
**What kind of change is this PR?**

chore

**What is the current behavior?**

#122 requested to use standard rules, but #123 just replaced tslint with eslint without using the proper rule set.

**What is the new behavior (if this is a feature change)?**

Use standard and standardx for linting now. Fix linting errors and remove tslint annotations.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [ ] Changelog has been updated
- [ ] Fix/Feature: JSDocs have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass
