### PR TITLE
chore: drop support for Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] (2019-??-??)
+## [Unreleased] (2020-??-??)
 ### Added
 - **list:** implement sublists
 
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **list:** text content of a list item cannot be styled, closes [#67](https://github.com/connium/simple-odf/issues/67)
 - **chore(lint):** replace tslint with eslint
 - **chore(travis):** add Node.js v12 to travis configuration
+- **chore:** drop support for Node.js 8
 
 ## [0.10.1] (2019-07-11)
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,9 +1248,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-      "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
+      "version": "10.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+      "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/jest": "^25.1.0",
-    "@types/node": "^8.10.35",
+    "@types/node": "^10.17.17",
     "@types/xmldom": "^0.1.29",
     "@typescript-eslint/eslint-plugin": "^2.3.3",
     "@typescript-eslint/parser": "^2.3.3",
@@ -56,7 +56,7 @@
     "typescript": "^3.3.3"
   },
   "engines": {
-    "node": "^8.9.4"
+    "node": "^10.x"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
**What kind of change is this PR?**

chore

**What is the current behavior?**

-

**What is the new behavior (if this is a feature change)?**

The 8.x Maintenance LTS cycle for Node.js has expired on December 31, 2019.
It is removed from the Travis configuration and the types for Node.js are updated.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Changelog has been updated
- [ ] Fix/Feature: JSDocs have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass
