### PR TITLE
chore(lint): use prettier for code formatting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,16 @@
 {
-  "rules": {
-    "semi": ["error", "always"],
-    "max-len": ["error", { "code": 120, "ignoreRegExpLiterals": true }],
-    "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": "error",
-    "no-useless-constructor": "off",
-    "@typescript-eslint/no-useless-constructor": "error"
-  },
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint",
+    "prettier"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier/@typescript-eslint"
+  ],
   "env": {
     "jest": true,
     "node": true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,5 +14,8 @@
   "env": {
     "jest": true,
     "node": true
+  },
+  "rules": {
+    "@typescript-eslint/interface-name-prefix": "off"
   }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **chore(lint):** replace tslint with eslint
 - **chore(travis):** add Node.js v12 to travis configuration
 - **chore:** drop support for Node.js 8
+- **chore(lint):** replace standard with prettier
 
 ## [0.10.1] (2019-07-11)
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ simple-odf is a library for creating Open Document Format text files using Types
 [![codecov](https://codecov.io/gh/connium/simple-odf/branch/master/graph/badge.svg)](https://codecov.io/gh/connium/simple-odf)
 [![Dependencies](https://david-dm.org/connium/simple-odf.svg)](https://david-dm.org/connium/simple-odf)
 [![Known Vulnerabilities](https://snyk.io/test/github/connium/simple-odf/badge.svg)](https://snyk.io/test/github/connium/simple-odf)
-[![Standard - JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ## Table of Contents
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 # Examples
 
 ## [Homer Resume](./homer-resume/)
+
 Resume of Homer Simpson. This is a full document using almost all features of the project.
 
 ![Screenshot Homer Simpson resume](./homer-resume/screenshot.png)

--- a/examples/homer-resume/index.ts
+++ b/examples/homer-resume/index.ts
@@ -1,4 +1,11 @@
-import { TextDocument, FontPitch, Color, ParagraphStyle, Typeface, TabStopType } from '../../';
+import {
+  TextDocument,
+  FontPitch,
+  Color,
+  ParagraphStyle,
+  Typeface,
+  TabStopType,
+} from '../../';
 
 const FILEPATH = './homer-resume.fodt';
 
@@ -55,18 +62,19 @@ meta.setTitle('Resume of Homer Simpson');
 meta.setLanguage('en-US');
 meta.addKeyword('Simpson,Springfield,Resume');
 
-document.getFontFaceDeclarations().create('FreeSans', 'FreeSans', FontPitch.Variable);
+document
+  .getFontFaceDeclarations()
+  .create('FreeSans', 'FreeSans', FontPitch.Variable);
 
 // twitter: @HomerJSimpson
 const body = document.getBody();
-body.addHeading('Homer Simpson')
-  .setStyle(titleStyle);
-body.addParagraph('Nuclear Safety Inspector')
-  .setStyle(subTitleStyle);
+body.addHeading('Homer Simpson').setStyle(titleStyle);
+body.addParagraph('Nuclear Safety Inspector').setStyle(subTitleStyle);
 
 body.addParagraph();
 
-body.addParagraph('Address: 742 Evergreen Terrace')
+body
+  .addParagraph('Address: 742 Evergreen Terrace')
   .setStyle(contactStyle)
   .addText('\n')
   .addText('Phone: 939-555-0113')
@@ -76,56 +84,67 @@ body.addParagraph('Address: 742 Evergreen Terrace')
 
 body.addParagraph();
 
-body.addParagraph('Award-winning nuclear safety inspector with 20 years experience')
+body
+  .addParagraph(
+    'Award-winning nuclear safety inspector with 20 years experience'
+  )
   .addText(', plus additional skills as snowplow driver.')
   .setStyle(defaultStyle);
 
 body.addParagraph();
 
 // experience
-body.addHeading('Experience', 2)
-  .setStyle(sectionTitleStyle);
+body.addHeading('Experience', 2).setStyle(sectionTitleStyle);
 
-body.addParagraph('1989 - present')
-  .setStyle(datesStyle);
-body.addHeading('Nuclear Safety Inspector', 3)
-  .setStyle(jobTitleStyle);
-body.addParagraph('Springfield Nuclear Power Plant, Springfield, USA')
+body.addParagraph('1989 - present').setStyle(datesStyle);
+body.addHeading('Nuclear Safety Inspector', 3).setStyle(jobTitleStyle);
+body
+  .addParagraph('Springfield Nuclear Power Plant, Springfield, USA')
   .setStyle(companyNameStyle);
 const list1 = body.addList();
-list1.addItem().addParagraph('Strengthened safety procedures that resulted in 75% fewer accidents on days I was absent');
-list1.addItem().addParagraph('Pioneered workplace stress-reduction methods that worked for at least one employee');
+list1
+  .addItem()
+  .addParagraph(
+    'Strengthened safety procedures that resulted in 75% fewer accidents on days I was absent'
+  );
+list1
+  .addItem()
+  .addParagraph(
+    'Pioneered workplace stress-reduction methods that worked for at least one employee'
+  );
 
 body.addParagraph();
 
-body.addParagraph('1992 - 1993')
-  .setStyle(datesStyle);
-body.addHeading('Owner and Chief Driver for Snow-Plowing Business', 3)
+body.addParagraph('1992 - 1993').setStyle(datesStyle);
+body
+  .addHeading('Owner and Chief Driver for Snow-Plowing Business', 3)
   .setStyle(jobTitleStyle);
-body.addParagraph('Mr. Plow, Springfield, USA')
-  .setStyle(companyNameStyle);
+body.addParagraph('Mr. Plow, Springfield, USA').setStyle(companyNameStyle);
 const list2 = body.addList();
-list2.addItem().addParagraph('Boosted business 15% by executing late-night TV marketing campaign');
-list2.addItem().addParagraph('Received key to the city in recognition of the achievements');
+list2
+  .addItem()
+  .addParagraph(
+    'Boosted business 15% by executing late-night TV marketing campaign'
+  );
+list2
+  .addItem()
+  .addParagraph('Received key to the city in recognition of the achievements');
 
 body.addParagraph();
 body.addParagraph();
 
 // education
-body.addHeading('Education', 2)
-  .setStyle(sectionTitleStyle);
+body.addHeading('Education', 2).setStyle(sectionTitleStyle);
 
-body.addParagraph('1993-10 - present')
-  .setStyle(datesStyle);
-body.addHeading('Degree in Nuclear Physics, Springfield University', 3)
+body.addParagraph('1993-10 - present').setStyle(datesStyle);
+body
+  .addHeading('Degree in Nuclear Physics, Springfield University', 3)
   .setStyle(jobTitleStyle);
 
 body.addParagraph();
 
-body.addParagraph('1969-10 - 1973-06')
-  .setStyle(datesStyle);
-body.addHeading('Springfield High School', 3)
-  .setStyle(jobTitleStyle);
+body.addParagraph('1969-10 - 1973-06').setStyle(datesStyle);
+body.addHeading('Springfield High School', 3).setStyle(jobTitleStyle);
 const list3 = body.addList();
 list3.addItem().addParagraph('Graduated 4-');
 
@@ -133,22 +152,24 @@ body.addParagraph();
 body.addParagraph();
 
 // skills
-body.addHeading('Skills', 2)
-  .setStyle(sectionTitleStyle);
+body.addHeading('Skills', 2).setStyle(sectionTitleStyle);
 
-body.addParagraph('Songwriting - invented golden record-winning GRUNGE music style')
+body
+  .addParagraph(
+    'Songwriting - invented golden record-winning GRUNGE music style'
+  )
   .setStyle(defaultStyle);
 
 body.addParagraph();
 body.addParagraph();
 
 // awards
-body.addHeading('Awards', 2)
-  .setStyle(sectionTitleStyle);
+body.addHeading('Awards', 2).setStyle(sectionTitleStyle);
 
-body.addParagraph('Montgomery Burns Award for Outstanding Service in the Field Excellence')
+body
+  .addParagraph(
+    'Montgomery Burns Award for Outstanding Service in the Field Excellence'
+  )
   .setStyle(defaultStyle);
 
-document.saveFlat(FILEPATH)
-  .then()
-  .catch();
+document.saveFlat(FILEPATH).then().catch();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1242,9 +1242,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
     "@types/node": {
@@ -1281,131 +1281,45 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz",
-      "integrity": "sha512-wJRBeaMeT7RLQ27UQkDFOu25MqFOBus8PtOa9KaT5ZuxC1kAsd7JEHqWt4YXuY9eancX0GK9C68i5OROnlIzBA==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.25.0.tgz",
+      "integrity": "sha512-W2YyMtjmlrOjtXc+FtTelVs9OhuR6OlYc4XKIslJ8PUJOqgYYAPRJhAqkYRQo3G4sjvG8jSodsNycEn4W2gHUw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.24.0",
-        "eslint-utils": "^1.4.3",
+        "@typescript-eslint/experimental-utils": "2.25.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "regexpp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz",
-      "integrity": "sha512-DXrwuXTdVh3ycNCMYmWhUzn/gfqu9N0VzNnahjiDJvcyhfBy4gb59ncVZVxdp5XzBC77dCncu0daQgOkbvPwBw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.25.0.tgz",
+      "integrity": "sha512-0IZ4ZR5QkFYbaJk+8eJ2kYeA+1tzOE1sBjbwwtSV85oNWYUBep+EyhlZ7DLUCyhMUGuJpcCCFL0fDtYAP1zMZw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.24.0",
-        "eslint-scope": "^5.0.0"
+        "@typescript-eslint/typescript-estree": "2.25.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.24.0.tgz",
-      "integrity": "sha512-H2Y7uacwSSg8IbVxdYExSI3T7uM1DzmOn2COGtCahCC3g8YtM1xYAPi2MAHyfPs61VKxP/J/UiSctcRgw4G8aw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.25.0.tgz",
+      "integrity": "sha512-mccBLaBSpNVgp191CP5W+8U1crTyXsRziWliCqzj02kpxdjKMvFHGJbK33NroquH3zB/gZ8H511HEsJBa2fNEg==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.24.0",
-        "@typescript-eslint/typescript-estree": "2.24.0",
+        "@typescript-eslint/experimental-utils": "2.25.0",
+        "@typescript-eslint/typescript-estree": "2.25.0",
         "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.24.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz",
-          "integrity": "sha512-DXrwuXTdVh3ycNCMYmWhUzn/gfqu9N0VzNnahjiDJvcyhfBy4gb59ncVZVxdp5XzBC77dCncu0daQgOkbvPwBw==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.24.0",
-            "eslint-scope": "^5.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.24.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz",
-          "integrity": "sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "eslint-visitor-keys": "^1.1.0",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash": "^4.17.15",
-            "semver": "^6.3.0",
-            "tsutils": "^3.17.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz",
-      "integrity": "sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.25.0.tgz",
+      "integrity": "sha512-VUksmx5lDxSi6GfmwSK7SSoIKSw9anukWWNitQPqt58LuYrKalzsgeuignbqnB+rK/xxGlSsCy8lYnwFfB6YJg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -1491,9 +1405,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "acorn-walk": {
@@ -1532,10 +1446,21 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
       "version": "4.1.0",
@@ -1600,16 +1525,6 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
-    },
-    "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
-      }
     },
     "array-unique": {
       "version": "0.3.2",
@@ -2042,12 +1957,12 @@
       }
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
@@ -2278,12 +2193,6 @@
         }
       }
     },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "dev": true
-    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -2370,12 +2279,6 @@
         "ms": "2.0.0"
       }
     },
-    "debug-log": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-      "dev": true
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -2447,28 +2350,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        }
-      }
-    },
-    "deglob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
-      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
-      "dev": true,
-      "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^5.0.0",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
-          "dev": true
         }
       }
     },
@@ -2559,9 +2440,9 @@
       }
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "end-of-stream": {
@@ -2578,40 +2459,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2633,9 +2480,9 @@
       }
     },
     "eslint": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
-      "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2645,19 +2492,19 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.2",
+        "eslint-utils": "^1.4.3",
         "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.1",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^11.7.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.4.1",
+        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -2666,7 +2513,7 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^6.1.2",
@@ -2686,292 +2533,49 @@
             "ms": "^2.1.1"
           }
         },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-config-standard": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
-      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
-      "dev": true
-    },
-    "eslint-config-standard-jsx": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
-      "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
-      "dev": true
-    },
-    "eslint-import-resolver-node": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
-      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^2.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
           }
         },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.1.0"
-          }
-        }
-      }
-    },
-    "eslint-plugin-es": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
-      "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
-      "dev": true,
-      "requires": {
-        "eslint-utils": "^1.4.2",
-        "regexpp": "^3.0.0"
-      },
-      "dependencies": {
         "regexpp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
           "dev": true
-        }
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
-      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.0.3",
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.9",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.4.0",
-        "has": "^1.0.3",
-        "minimatch": "^3.0.4",
-        "object.values": "^1.1.0",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.11.0"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
-          }
-        },
-        "resolve": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        }
-      }
-    },
-    "eslint-plugin-node": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
-      "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-es": "^2.0.0",
-        "eslint-utils": "^1.4.2",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
         },
         "semver": {
           "version": "6.3.0",
@@ -2981,54 +2585,23 @@
         }
       }
     },
-    "eslint-plugin-promise": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
-      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
-      "dev": true
-    },
-    "eslint-plugin-react": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
-      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+    "eslint-config-prettier": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.1.0",
-        "object.entries": "^1.1.0",
-        "object.fromentries": "^2.0.0",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2",
-        "resolve": "^1.10.1"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "resolve": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        }
+        "get-stdin": "^6.0.0"
       }
     },
-    "eslint-plugin-standard": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
-      "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
-      "dev": true
+    "eslint-plugin-prettier": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
     },
     "eslint-scope": {
       "version": "5.0.0",
@@ -3041,12 +2614,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -3056,13 +2629,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -3073,12 +2646,20 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.0.tgz",
+      "integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.0.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
+          "integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
@@ -3372,6 +2953,12 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -3394,9 +2981,9 @@
       }
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -3463,21 +3050,6 @@
         }
       }
     },
-    "find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true
-    },
-    "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "requires": {
-        "locate-path": "^3.0.0"
-      }
-    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -3501,9 +3073,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "for-in": {
@@ -3582,9 +3154,9 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -3626,9 +3198,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -3742,12 +3314,6 @@
         }
       }
     },
-    "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
-      "dev": true
-    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -3796,9 +3362,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -3846,51 +3412,95 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -3921,22 +3531,10 @@
         }
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-ci": {
@@ -4006,9 +3604,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-generator-fn": {
@@ -4046,15 +3644,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -6708,12 +6297,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -6767,16 +6350,6 @@
         "verror": "1.10.0"
       }
     },
-    "jsx-ast-utils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
-      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.0.3",
-        "object.assign": "^4.1.0"
-      }
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6821,16 +6394,6 @@
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
-      }
-    },
-    "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -6882,15 +6445,6 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "make-dir": {
@@ -7003,9 +6557,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimatch": {
@@ -7074,9 +6628,9 @@
       "dev": true
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "nanomatch": {
@@ -7151,18 +6705,6 @@
         }
       }
     },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -7188,12 +6730,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
@@ -7233,12 +6769,6 @@
       "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
       "dev": true
     },
-    "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-      "dev": true
-    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -7270,50 +6800,6 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
-      }
-    },
-    "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      }
-    },
-    "object.fromentries": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.15.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.0",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.0",
-            "is-callable": "^1.1.4",
-            "is-regex": "^1.0.4",
-            "object-inspect": "^1.6.0",
-            "object-keys": "^1.1.1",
-            "string.prototype.trimleft": "^2.1.0",
-            "string.prototype.trimright": "^2.1.0"
-          }
-        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -7414,18 +6900,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7436,12 +6910,12 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optimist": {
@@ -7503,15 +6977,6 @@
         "p-try": "^2.0.0"
       }
     },
-    "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "requires": {
-        "p-limit": "^2.0.0"
-      }
-    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -7527,16 +6992,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      }
-    },
     "parse5": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
@@ -7547,12 +7002,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
@@ -7592,48 +7041,6 @@
       "dev": true,
       "requires": {
         "node-modules-regexp": "^1.0.0"
-      }
-    },
-    "pkg-conf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
-      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
-      "dev": true,
-      "requires": {
-        "find-up": "^3.0.0",
-        "load-json-file": "^5.2.0"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
-          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.15",
-            "parse-json": "^4.0.0",
-            "pify": "^4.0.1",
-            "strip-bom": "^3.0.0",
-            "type-fest": "^0.3.0"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        }
-      }
-    },
-    "pkg-config": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
-      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-      "dev": true,
-      "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
       }
     },
     "pkg-dir": {
@@ -7698,6 +7105,21 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "prettier": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-format": {
       "version": "25.1.0",
@@ -7766,17 +7188,6 @@
         "sisteransi": "^1.0.3"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "psl": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
@@ -7803,12 +7214,6 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
-    },
-    "react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
       "dev": true
     },
     "realpath-native": {
@@ -7903,9 +7308,9 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+      "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
       "dev": true
     },
     "remove-trailing-separator": {
@@ -8064,12 +7469,12 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
@@ -8095,24 +7500,18 @@
       "dev": true
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
     },
-    "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-      "dev": true
-    },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -8379,6 +7778,14 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
       }
     },
     "snapdragon": {
@@ -8551,38 +7958,6 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-      "dev": true
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -8620,53 +7995,6 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
-    },
-    "standard": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-14.3.1.tgz",
-      "integrity": "sha512-TUQwU7znlZLfgKH1Zwn/D84FitWZkUTfbxSiz/vFx+4c9GV+clSfG/qLiLZOlcdyzhw3oF5/pZydNjbNDfHPEw==",
-      "dev": true,
-      "requires": {
-        "eslint": "~6.4.0",
-        "eslint-config-standard": "14.1.0",
-        "eslint-config-standard-jsx": "8.1.0",
-        "eslint-plugin-import": "~2.18.0",
-        "eslint-plugin-node": "~10.0.0",
-        "eslint-plugin-promise": "~4.2.1",
-        "eslint-plugin-react": "~7.14.2",
-        "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "^12.0.0"
-      }
-    },
-    "standard-engine": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.0.tgz",
-      "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
-      "dev": true,
-      "requires": {
-        "deglob": "^4.0.0",
-        "get-stdin": "^7.0.0",
-        "minimist": "^1.1.0",
-        "pkg-conf": "^3.1.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "standardx": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/standardx/-/standardx-5.0.0.tgz",
-      "integrity": "sha512-dWbhU91EqwwWTED224B4X0h1q01Tv2wIv30mFz4NOQ+JMEJKtCrBOUEgMpBIynSFm6MDJYr+H7xUPVMYjGd8HA==",
-      "dev": true,
-      "requires": {
-        "standard": "^14.0.0",
-        "standard-engine": "^12.0.0"
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -8732,34 +8060,31 @@
       }
     },
     "string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "strip-ansi": {
@@ -8770,12 +8095,6 @@
       "requires": {
         "ansi-regex": "^4.1.0"
       }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -8847,6 +8166,31 @@
         "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
       }
     },
     "table-layout": {
@@ -9079,9 +8423,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
     },
     "tsutils": {
@@ -9124,9 +8468,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
     "typedarray-to-buffer": {
@@ -9184,12 +8528,6 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
-    },
-    "uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -9374,16 +8712,6 @@
         }
       }
     },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -9475,6 +8803,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wordwrap": {
@@ -9624,12 +8958,6 @@
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "jest",
     "watch-test": "jest --watch",
     "coverage": "jest --coverage",
-    "lint": "eslint './{examples,test}/**/*.{ts,tsx}'",
+    "lint": "eslint './{examples,src,test}/**/*.{ts,tsx}'",
     "format": "prettier --write './{examples,src,test}/**/*.{ts,js,json,md}'",
     "docs": "rm -r ./lib && tsc && jsdoc2md --name-format --param-list-format list --separators --partial ./tools/jsdoc2md/body.hbs ./tools/jsdoc2md/params-list.hbs ./tools/jsdoc2md/returns.hbs ./tools/jsdoc2md/scope.hbs --files ./lib/api/**/*.js > ./docs/API.md"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test": "jest",
     "watch-test": "jest --watch",
     "coverage": "jest --coverage",
-    "lint": "standardx \"src/**/*.ts\"  \"test/**/*.ts\"",
+    "lint": "eslint './{examples,test}/**/*.{ts,tsx}'",
+    "format": "prettier --write './{examples,src,test}/**/*.{ts,js,json,md}'",
     "docs": "rm -r ./lib && tsc && jsdoc2md --name-format --param-list-format list --separators --partial ./tools/jsdoc2md/body.hbs ./tools/jsdoc2md/params-list.hbs ./tools/jsdoc2md/returns.hbs ./tools/jsdoc2md/scope.hbs --files ./lib/api/**/*.js > ./docs/API.md"
   },
   "dependencies": {
@@ -47,11 +48,14 @@
     "@types/jest": "^25.1.0",
     "@types/node": "^10.17.17",
     "@types/xmldom": "^0.1.29",
-    "@typescript-eslint/eslint-plugin": "^2.3.3",
-    "@typescript-eslint/parser": "^2.3.3",
+    "@typescript-eslint/eslint-plugin": "^2.25.0",
+    "@typescript-eslint/parser": "^2.25.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.1",
+    "eslint-plugin-prettier": "^3.1.2",
     "jest": "^25.1.0",
     "jsdoc-to-markdown": "^5.0.0",
-    "standardx": "^5.0.0",
+    "prettier": "2.0.2",
     "ts-jest": "^25.0.0",
     "typescript": "^3.3.3"
   },
@@ -68,11 +72,5 @@
       "js"
     ],
     "collectCoverage": true
-  },
-  "standardx": {
-    "parser": "@typescript-eslint/parser",
-    "plugins": [
-      "@typescript-eslint/eslint-plugin"
-    ]
   }
 }

--- a/src/api/OdfElement.ts
+++ b/src/api/OdfElement.ts
@@ -10,7 +10,7 @@ export class OdfElement {
    * Constructor.
    * @since 0.1.0
    */
-  public constructor () {
+  public constructor() {
     this.children = [];
   }
 
@@ -20,7 +20,7 @@ export class OdfElement {
    * @returns {OdfElement[]} A copy of the list of child elements
    * @since 0.2.0
    */
-  public getAll (): OdfElement[] {
+  public getAll(): OdfElement[] {
     return Array.from(this.children);
   }
 
@@ -30,7 +30,7 @@ export class OdfElement {
    * @param {OdfElement} element The element to append
    * @since 0.1.0
    */
-  protected append (element: OdfElement): void {
+  protected append(element: OdfElement): void {
     this.children.push(element);
   }
 
@@ -43,7 +43,7 @@ export class OdfElement {
    * @param {OdfElement} element The element to insert
    * @since 0.2.0
    */
-  protected insert (position: number, element: OdfElement): void {
+  protected insert(position: number, element: OdfElement): void {
     let index = position;
 
     if (position < 0) {
@@ -63,7 +63,7 @@ export class OdfElement {
    * or undefined if there is no element at the specified position
    * @since 0.2.0
    */
-  protected get (position: number): OdfElement | undefined {
+  protected get(position: number): OdfElement | undefined {
     if (position < 0) {
       return undefined;
     }
@@ -82,7 +82,7 @@ export class OdfElement {
    * or undefined if there is no element at the specified position
    * @since 0.2.0
    */
-  protected removeAt (position: number): OdfElement | undefined {
+  protected removeAt(position: number): OdfElement | undefined {
     const oldElement = this.get(position);
 
     if (oldElement !== undefined) {
@@ -98,7 +98,7 @@ export class OdfElement {
    * @returns {boolean} TRUE if the there is any child element, FALSE otherwise
    * @since 0.2.0
    */
-  protected hasChildren (): boolean {
+  protected hasChildren(): boolean {
     return this.children.length > 0;
   }
 }

--- a/src/api/draw/AnchorType.ts
+++ b/src/api/draw/AnchorType.ts
@@ -3,5 +3,5 @@ export enum AnchorType {
   Char = 'char',
   Frame = 'frame',
   Page = 'page',
-  Paragraph = 'paragraph'
+  Paragraph = 'paragraph',
 }

--- a/src/api/draw/Image.ts
+++ b/src/api/draw/Image.ts
@@ -32,7 +32,7 @@ export class Image extends OdfElement {
    * @param {string} path Path to the image file that should be embedded
    * @since 0.3.0
    */
-  public constructor (private path: string) {
+  public constructor(private path: string) {
     super();
 
     this.anchorType = DEFAULT_ANCHOR_TYPE;
@@ -49,7 +49,7 @@ export class Image extends OdfElement {
    * @returns {Image} The `Image` object
    * @since 0.9.0
    */
-  public setAnchorType (anchorType: AnchorType): Image {
+  public setAnchorType(anchorType: AnchorType): Image {
     this.anchorType = anchorType;
 
     return this;
@@ -67,7 +67,7 @@ export class Image extends OdfElement {
    * @returns {AnchorType} The anchor type setting
    * @since 0.9.0
    */
-  public getAnchorType (): AnchorType {
+  public getAnchorType(): AnchorType {
     return this.anchorType;
   }
 
@@ -85,7 +85,7 @@ export class Image extends OdfElement {
    * @returns {Image} The `Image` object
    * @since 0.9.0
    */
-  public setHeight (height: number): Image {
+  public setHeight(height: number): Image {
     this.height = Math.max(height, MINIMAL_SIZE);
 
     return this;
@@ -103,7 +103,7 @@ export class Image extends OdfElement {
    * @returns {number | undefined} The target height of the image in millimeter or `undefined` if no height was set
    * @since 0.9.0
    */
-  public getHeight (): number | undefined {
+  public getHeight(): number | undefined {
     return this.height;
   }
 
@@ -117,7 +117,7 @@ export class Image extends OdfElement {
    * @returns {string} The path to the image file
    * @since 0.7.0
    */
-  public getPath (): string {
+  public getPath(): string {
     return this.path;
   }
 
@@ -136,7 +136,7 @@ export class Image extends OdfElement {
    * @returns {Image} The `Image` object
    * @since 0.9.0
    */
-  public setSize (width: number, height: number): Image {
+  public setSize(width: number, height: number): Image {
     this.setWidth(width);
     this.setHeight(height);
 
@@ -157,7 +157,7 @@ export class Image extends OdfElement {
    * @returns {Image} The `Image` object
    * @since 0.9.0
    */
-  public setWidth (width: number): Image {
+  public setWidth(width: number): Image {
     this.width = Math.max(width, MINIMAL_SIZE);
 
     return this;
@@ -175,7 +175,7 @@ export class Image extends OdfElement {
    * @returns {number | undefined} The target width of the image in millimeter or `undefined` if no width was set
    * @since 0.9.0
    */
-  public getWidth (): number | undefined {
+  public getWidth(): number | undefined {
     return this.width;
   }
 }

--- a/src/api/meta/Meta.spec.ts
+++ b/src/api/meta/Meta.spec.ts
@@ -12,7 +12,9 @@ describe(Meta.name, () => {
 
   describe('creation date', () => {
     it('return current date', () => {
-      expect(meta.getCreationDate().getTime()).toBeGreaterThan(Date.now() - timeOffset);
+      expect(meta.getCreationDate().getTime()).toBeGreaterThan(
+        Date.now() - timeOffset
+      );
     });
   });
 
@@ -186,7 +188,11 @@ describe(Meta.name, () => {
       meta.addKeyword(testKeyword2);
       meta.addKeyword(testKeyword1);
 
-      expect(meta.getKeywords()).toEqual([testKeyword1, testKeyword2, testKeyword1]);
+      expect(meta.getKeywords()).toEqual([
+        testKeyword1,
+        testKeyword2,
+        testKeyword1,
+      ]);
 
       meta.removeKeyword(testKeyword1);
 
@@ -202,7 +208,11 @@ describe(Meta.name, () => {
       meta.addKeyword(testKeyword2);
       meta.addKeyword(testKeyword1);
 
-      expect(meta.getKeywords()).toEqual([testKeyword1, testKeyword2, testKeyword1]);
+      expect(meta.getKeywords()).toEqual([
+        testKeyword1,
+        testKeyword2,
+        testKeyword1,
+      ]);
 
       meta.clearKeywords();
 

--- a/src/api/meta/Meta.ts
+++ b/src/api/meta/Meta.ts
@@ -49,7 +49,8 @@ export class Meta {
    *
    * @since 0.6.0
    */
-  public constructor () {
+  public constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const packageJson = require('../../../package.json');
 
     this.generator = `${packageJson.name}/${packageJson.version}`;
@@ -72,7 +73,7 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public setCreator (creator: string | undefined): Meta {
+  public setCreator(creator: string | undefined): Meta {
     if (creator === undefined || typeof creator === 'string') {
       this.creator = creator;
     }
@@ -93,7 +94,7 @@ export class Meta {
    *                               or `undefined` if the creator is not set
    * @since 0.6.0
    */
-  public getCreator (): string | undefined {
+  public getCreator(): string | undefined {
     return this.creator;
   }
 
@@ -109,7 +110,7 @@ export class Meta {
    * @returns {Date} A `Date` instance specifying the date and time when a document was created
    * @since 0.6.0
    */
-  public getCreationDate (): Date {
+  public getCreationDate(): Date {
     return this.creationDate;
   }
 
@@ -125,8 +126,11 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public setDate (date: Date | undefined): Meta {
-    if (date === undefined || (date instanceof Date && date.getTime() >= Date.now())) {
+  public setDate(date: Date | undefined): Meta {
+    if (
+      date === undefined ||
+      (date instanceof Date && date.getTime() >= Date.now())
+    ) {
       this.date = date;
     }
 
@@ -146,7 +150,7 @@ export class Meta {
    *                             or `undefined` if the date is not set
    * @since 0.6.0
    */
-  public getDate (): Date | undefined {
+  public getDate(): Date | undefined {
     return this.date;
   }
 
@@ -161,7 +165,7 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public setDescription (description: string | undefined): Meta {
+  public setDescription(description: string | undefined): Meta {
     if (description === undefined || typeof description === 'string') {
       this.description = description;
     }
@@ -181,7 +185,7 @@ export class Meta {
    * @returns {string | undefined} The description of the document or `undefined` if the description is not set
    * @since 0.6.0
    */
-  public getDescription (): string | undefined {
+  public getDescription(): string | undefined {
     return this.description;
   }
 
@@ -197,7 +201,7 @@ export class Meta {
    * @returns {number} The number of times a document has been edited
    * @since 0.6.0
    */
-  public getEditingCycles (): number {
+  public getEditingCycles(): number {
     return this.editingCycles;
   }
 
@@ -213,7 +217,7 @@ export class Meta {
    * @returns {string} A string that identifies **simple-odf** as the OpenDocument producer of this document
    * @since 0.6.0
    */
-  public getGenerator (): string {
+  public getGenerator(): string {
     return this.generator;
   }
 
@@ -232,7 +236,7 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public setInitialCreator (initialCreator: string | undefined): Meta {
+  public setInitialCreator(initialCreator: string | undefined): Meta {
     if (initialCreator === undefined || typeof initialCreator === 'string') {
       this.initialCreator = initialCreator;
     }
@@ -253,7 +257,7 @@ export class Meta {
    *                               or `undefined` if the initial creator is not set
    * @since 0.6.0
    */
-  public getInitialCreator (): string | undefined {
+  public getInitialCreator(): string | undefined {
     return this.initialCreator;
   }
 
@@ -270,7 +274,7 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public addKeyword (keyword: string): Meta {
+  public addKeyword(keyword: string): Meta {
     if (typeof keyword === 'string') {
       this.keywords.push(...keyword.split(','));
     }
@@ -290,7 +294,7 @@ export class Meta {
    * @returns {string[]} A new `Array` object that contains the keywords of the document
    * @since 0.6.0
    */
-  public getKeywords (): string[] {
+  public getKeywords(): string[] {
     return Array.from(this.keywords);
   }
 
@@ -306,8 +310,10 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public removeKeyword (keyword: string): Meta {
-    this.keywords = this.keywords.filter((existingKeyword: string) => existingKeyword !== keyword);
+  public removeKeyword(keyword: string): Meta {
+    this.keywords = this.keywords.filter(
+      (existingKeyword: string) => existingKeyword !== keyword
+    );
 
     return this;
   }
@@ -323,7 +329,7 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public clearKeywords (): Meta {
+  public clearKeywords(): Meta {
     this.keywords = [];
 
     return this;
@@ -344,8 +350,11 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public setLanguage (language: string | undefined): Meta {
-    if (language === undefined || /^[a-z]{2}(-[A-Z]{2})?$/.test(language) === true) {
+  public setLanguage(language: string | undefined): Meta {
+    if (
+      language === undefined ||
+      /^[a-z]{2}(-[A-Z]{2})?$/.test(language) === true
+    ) {
       this.language = language;
     }
 
@@ -365,7 +374,7 @@ export class Meta {
    *                               or `undefined` if the default language is not set
    * @since 0.6.0
    */
-  public getLanguage (): string | undefined {
+  public getLanguage(): string | undefined {
     return this.language;
   }
 
@@ -381,8 +390,11 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public setPrintDate (printDate: Date | undefined): Meta {
-    if (printDate === undefined || (printDate instanceof Date && printDate.getTime() >= Date.now())) {
+  public setPrintDate(printDate: Date | undefined): Meta {
+    if (
+      printDate === undefined ||
+      (printDate instanceof Date && printDate.getTime() >= Date.now())
+    ) {
       this.printDate = printDate;
     }
 
@@ -402,7 +414,7 @@ export class Meta {
    *                             or `undefined` if the print date is not set
    * @since 0.6.0
    */
-  public getPrintDate (): Date | undefined {
+  public getPrintDate(): Date | undefined {
     return this.printDate;
   }
 
@@ -419,7 +431,7 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public setPrintedBy (printedBy: string | undefined): Meta {
+  public setPrintedBy(printedBy: string | undefined): Meta {
     if (printedBy === undefined || typeof printedBy === 'string') {
       this.printedBy = printedBy;
     }
@@ -440,7 +452,7 @@ export class Meta {
    *                               or `undefined` if the name of the person is not set
    * @since 0.6.0
    */
-  public getPrintedBy (): string | undefined {
+  public getPrintedBy(): string | undefined {
     return this.printedBy;
   }
 
@@ -456,7 +468,7 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public setSubject (subject: string | undefined): Meta {
+  public setSubject(subject: string | undefined): Meta {
     if (subject === undefined || typeof subject === 'string') {
       this.subject = subject;
     }
@@ -476,7 +488,7 @@ export class Meta {
    * @returns {string | undefined} The subject of the document or `undefined` if the subject is not set
    * @since 0.6.0
    */
-  public getSubject (): string | undefined {
+  public getSubject(): string | undefined {
     return this.subject;
   }
 
@@ -492,7 +504,7 @@ export class Meta {
    * @returns {Meta} The `Meta` object
    * @since 0.6.0
    */
-  public setTitle (title: string | undefined): Meta {
+  public setTitle(title: string | undefined): Meta {
     if (title === undefined || typeof title === 'string') {
       this.title = title;
     }
@@ -512,7 +524,7 @@ export class Meta {
    * @returns {string | undefined} The title of the document or `undefined` if the title is not set
    * @since 0.6.0
    */
-  public getTitle (): string | undefined {
+  public getTitle(): string | undefined {
     return this.title;
   }
 }

--- a/src/api/office/AutomaticStyles.ts
+++ b/src/api/office/AutomaticStyles.ts
@@ -33,7 +33,7 @@ export class AutomaticStyles implements IStyles {
    *
    * @since 0.9.0
    */
-  public constructor () {
+  public constructor() {
     this.styles = new Map();
     this.paragraphStyleCounter = 0;
   }
@@ -54,14 +54,17 @@ export class AutomaticStyles implements IStyles {
    * @param {Style} style The style which should be added to the list of automatic styles
    * @since 0.9.0
    */
-  public add (style: Style): void {
+  public add(style: Style): void {
     const hash = this.getHash(style);
 
     if (this.styles.has(hash)) {
       return;
     }
 
-    this.styles.set(hash, { style: style, name: `P${++this.paragraphStyleCounter}` });
+    this.styles.set(hash, {
+      style: style,
+      name: `P${++this.paragraphStyleCounter}`,
+    });
   }
 
   /**
@@ -80,7 +83,7 @@ export class AutomaticStyles implements IStyles {
    * @throws {Error} If the style has not been added to the list of automatic styles
    * @since 0.9.0
    */
-  public getName (style: Style): string | never {
+  public getName(style: Style): string | never {
     const hash = this.getHash(style);
     const styleInformation = this.styles.get(hash);
 
@@ -92,7 +95,7 @@ export class AutomaticStyles implements IStyles {
   }
 
   /** @inheritdoc */
-  public getAll (): Style[] {
+  public getAll(): Style[] {
     return Array.from(this.styles.values())
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((styleInformation) => styleInformation.style);
@@ -104,7 +107,7 @@ export class AutomaticStyles implements IStyles {
    * @param {Style} style The style for which a representative hash is being requested
    * @returns {string} The hash representing the given style
    */
-  private getHash (style: Style): string {
+  private getHash(style: Style): string {
     const hash = createHash('md5');
 
     hash.update(style.getClass() || '');
@@ -140,7 +143,9 @@ export class AutomaticStyles implements IStyles {
       hash.update(paragraphStyle.getVerticalAlignment());
       hash.update('widows' + paragraphStyle.getWidows());
       paragraphStyle.getTabStops().forEach((tabStop) => {
-        hash.update(`tab${tabStop.getChar()}${tabStop.getLeaderColor()}${tabStop.getLeaderStyle()}${tabStop.getPosition()}${tabStop.getType()}`); // eslint-disable-line max-len
+        hash.update(
+          `tab${tabStop.getChar()}${tabStop.getLeaderColor()}${tabStop.getLeaderStyle()}${tabStop.getPosition()}${tabStop.getType()}`
+        ); // eslint-disable-line max-len
       });
 
       // text properties

--- a/src/api/office/CommonStyles.ts
+++ b/src/api/office/CommonStyles.ts
@@ -23,7 +23,7 @@ export class CommonStyles implements IStyles {
    *
    * @since 0.9.0
    */
-  public constructor () {
+  public constructor() {
     this.styles = new Map();
   }
 
@@ -40,7 +40,7 @@ export class CommonStyles implements IStyles {
    * or an existing style, if one with the specified name exists
    * @since 0.9.0
    */
-  public createParagraphStyle (name: string): ParagraphStyle {
+  public createParagraphStyle(name: string): ParagraphStyle {
     let style = this.styles.get(name);
 
     if (style !== undefined) {
@@ -67,14 +67,14 @@ export class CommonStyles implements IStyles {
    * or `undefined` if there is no style with this display name
    * @since 0.9.0
    */
-  public getName (displayName: string): string | undefined {
+  public getName(displayName: string): string | undefined {
     const style = this.styles.get(displayName);
 
     return style !== undefined ? style.getName() : undefined;
   }
 
   /** @inheritdoc */
-  public getAll (): Style[] {
+  public getAll(): Style[] {
     return [...this.styles.values()];
   }
 }

--- a/src/api/office/FontFaceDeclarations.spec.ts
+++ b/src/api/office/FontFaceDeclarations.spec.ts
@@ -20,7 +20,11 @@ describe(FontFaceDeclarations.name, () => {
     });
 
     it('create and return new font', () => {
-      const font = fontFaceDeclarations.create(testFontName, testFontFamily, testFontPitch);
+      const font = fontFaceDeclarations.create(
+        testFontName,
+        testFontFamily,
+        testFontPitch
+      );
 
       expect(font).toBeInstanceOf(FontFace);
       expect(font.getFontFamily()).toBe(testFontFamily);

--- a/src/api/office/FontFaceDeclarations.ts
+++ b/src/api/office/FontFaceDeclarations.ts
@@ -29,7 +29,11 @@ export class FontFaceDeclarations {
    * or an existing font face, if one with the specified name exists
    * @since 0.8.0
    */
-  public create (name: string, fontFamily?: string, fontPitch?: FontPitch): FontFace {
+  public create(
+    name: string,
+    fontFamily?: string,
+    fontPitch?: FontPitch
+  ): FontFace {
     let fontFace = this.fontFaces.get(name);
 
     if (fontFace !== undefined) {
@@ -56,7 +60,7 @@ export class FontFaceDeclarations {
    * or `undefined` if there is no font with this name
    * @since 0.8.0
    */
-  public get (name: string): FontFace | undefined {
+  public get(name: string): FontFace | undefined {
     return this.fontFaces.get(name);
   }
 
@@ -72,7 +76,7 @@ export class FontFaceDeclarations {
    * @returns {FontFace[]} A new `Array` object that contains the fonts of the document
    * @since 0.8.0
    */
-  public getAll (): FontFace[] {
+  public getAll(): FontFace[] {
     return [...this.fontFaces.values()];
   }
 
@@ -91,7 +95,7 @@ export class FontFaceDeclarations {
    * @returns {Meta} The `Meta` object
    * @since 0.8.0
    */
-  public delete (name: string): FontFaceDeclarations {
+  public delete(name: string): FontFaceDeclarations {
     this.fontFaces.delete(name);
 
     return this;

--- a/src/api/office/IStyles.ts
+++ b/src/api/office/IStyles.ts
@@ -13,5 +13,5 @@ export interface IStyles {
    * @returns {Style[]} A new `Array` object that contains the named or automatic styles of a document
    * @since 0.9.0
    */
-  getAll (): Style[];
+  getAll(): Style[];
 }

--- a/src/api/office/TextBody.ts
+++ b/src/api/office/TextBody.ts
@@ -22,7 +22,7 @@ export class TextBody extends OdfElement {
    * @returns {Heading} The newly added heading
    * @since 0.7.0
    */
-  public addHeading (text?: string, level = 1): Heading {
+  public addHeading(text?: string, level = 1): Heading {
     const heading = new Heading(text, level);
     this.append(heading);
 
@@ -39,7 +39,7 @@ export class TextBody extends OdfElement {
    * @returns {List} The newly added list
    * @since 0.7.0
    */
-  public addList (): List {
+  public addList(): List {
     const list = new List();
     this.append(list);
 
@@ -54,7 +54,7 @@ export class TextBody extends OdfElement {
    * @returns {Paragraph} The newly added paragraph
    * @since 0.7.0
    */
-  public addParagraph (text?: string): Paragraph {
+  public addParagraph(text?: string): Paragraph {
     const paragraph = new Paragraph(text);
     this.append(paragraph);
 

--- a/src/api/office/TextDocument.ts
+++ b/src/api/office/TextDocument.ts
@@ -36,7 +36,7 @@ export class TextDocument {
    *
    * @since 0.1.0
    */
-  public constructor () {
+  public constructor() {
     this.meta = new Meta();
     this.fontFaceDeclarations = new FontFaceDeclarations();
     this.commonStyles = new CommonStyles();
@@ -54,7 +54,7 @@ export class TextDocument {
    * @returns {TextBody} A `TextBody` object that holds the content of the document
    * @since 0.7.0
    */
-  public getBody (): TextBody {
+  public getBody(): TextBody {
     return this.body;
   }
 
@@ -69,7 +69,7 @@ export class TextDocument {
    * @returns {CommonStyles} A `CommonStyles` object that holds the named styles of the document
    * @since 0.9.0
    */
-  public getCommonStyles (): CommonStyles {
+  public getCommonStyles(): CommonStyles {
     return this.commonStyles;
   }
 
@@ -84,7 +84,7 @@ export class TextDocument {
    * @returns {FontFaceDeclarations} An object holding the font faces of the document
    * @since 0.8.0
    */
-  public getFontFaceDeclarations (): FontFaceDeclarations {
+  public getFontFaceDeclarations(): FontFaceDeclarations {
     return this.fontFaceDeclarations;
   }
 
@@ -99,7 +99,7 @@ export class TextDocument {
    * @returns {Meta} An object holding the metadata of the document
    * @since 0.6.0
    */
-  public getMeta (): Meta {
+  public getMeta(): Meta {
     return this.meta;
   }
 
@@ -114,7 +114,7 @@ export class TextDocument {
    * @returns {Promise<void>}
    * @since 0.1.0
    */
-  public saveFlat (filePath: string): Promise<void> {
+  public saveFlat(filePath: string): Promise<void> {
     const writeFileAsync = promisify(writeFile);
     const xml = this.toString();
 
@@ -127,7 +127,7 @@ export class TextDocument {
    * @returns {string} The string representation of this document
    * @since 0.1.0
    */
-  public toString (): string {
+  public toString(): string {
     const document = new TextDocumentWriter().write(this);
 
     return XML_DECLARATION + new XMLSerializer().serializeToString(document);

--- a/src/api/style/BorderStyle.ts
+++ b/src/api/style/BorderStyle.ts
@@ -7,5 +7,5 @@ export enum BorderStyle {
   // Inset = 'inset',
   // Outset = 'outset',
   // Ridge = 'ridge',
-  Solid = 'solid'
+  Solid = 'solid',
 }

--- a/src/api/style/Color.spec.ts
+++ b/src/api/style/Color.spec.ts
@@ -40,19 +40,25 @@ describe(Color.name, () => {
     it('return undefined if red is out of range', () => {
       expect(() => Color.fromRgb(-1, 0x66, 0x99)).toThrowError('color channel');
 
-      expect(() => Color.fromRgb(256, 0x66, 0x99)).toThrowError('color channel');
+      expect(() => Color.fromRgb(256, 0x66, 0x99)).toThrowError(
+        'color channel'
+      );
     });
 
     it('return undefined if green is out of range', () => {
       expect(() => Color.fromRgb(0x33, -1, 0x99)).toThrowError('color channel');
 
-      expect(() => Color.fromRgb(0x33, 256, 0x99)).toThrowError('color channel');
+      expect(() => Color.fromRgb(0x33, 256, 0x99)).toThrowError(
+        'color channel'
+      );
     });
 
     it('return undefined if blue is out of range', () => {
       expect(() => Color.fromRgb(0x33, 0x66, -1)).toThrowError('color channel');
 
-      expect(() => Color.fromRgb(0x33, 0x66, 256)).toThrowError('color channel');
+      expect(() => Color.fromRgb(0x33, 0x66, 256)).toThrowError(
+        'color channel'
+      );
     });
   });
 

--- a/src/api/style/Color.ts
+++ b/src/api/style/Color.ts
@@ -13,13 +13,17 @@ export class Color {
    * @throws {Error} If the value cannot be converted to a color
    * @since 0.4.0
    */
-  public static fromHex (value: string): Color | never {
+  public static fromHex(value: string): Color | never {
     const matches = value.match(/^#?([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/);
     if (matches === null) {
       throw new Error('Invalid color value');
     }
 
-    return new Color(parseInt(matches[1], 16), parseInt(matches[2], 16), parseInt(matches[3], 16));
+    return new Color(
+      parseInt(matches[1], 16),
+      parseInt(matches[2], 16),
+      parseInt(matches[3], 16)
+    );
   }
 
   /**
@@ -32,8 +36,16 @@ export class Color {
    * @throws {Error} If any channel is outside the allowable range
    * @since 0.4.0
    */
-  public static fromRgb (red: number, green: number, blue: number): Color | never {
-    if (Color.checkRange(red) && Color.checkRange(green) && Color.checkRange(blue)) {
+  public static fromRgb(
+    red: number,
+    green: number,
+    blue: number
+  ): Color | never {
+    if (
+      Color.checkRange(red) &&
+      Color.checkRange(green) &&
+      Color.checkRange(blue)
+    ) {
       return new Color(red, green, blue);
     }
     throw new Error('Invalid value for a color channel');
@@ -47,7 +59,7 @@ export class Color {
    * @since 0.4.0
    * @private
    */
-  private static checkRange (value: number): boolean {
+  private static checkRange(value: number): boolean {
     return value >= 0 && value <= 255;
   }
 
@@ -59,7 +71,7 @@ export class Color {
    * @since 0.4.0
    * @private
    */
-  private static numberToHex (value: number): string {
+  private static numberToHex(value: number): string {
     const hexString = value.toString(16);
     if (hexString.length === 2) {
       return hexString;
@@ -77,8 +89,11 @@ export class Color {
    * @since 0.4.0
    * @private
    */
-  private constructor (private red: number, private green: number, private blue: number) {
-  }
+  private constructor(
+    private red: number,
+    private green: number,
+    private blue: number
+  ) {}
 
   /**
    * The toHex() method returns a string representing the color as hex string.
@@ -86,7 +101,9 @@ export class Color {
    * @returns {string} A hex string representing the color
    * @since 0.4.0
    */
-  public toHex (): string {
-    return `#${Color.numberToHex(this.red)}${Color.numberToHex(this.green)}${Color.numberToHex(this.blue)}`;
+  public toHex(): string {
+    return `#${Color.numberToHex(this.red)}${Color.numberToHex(
+      this.green
+    )}${Color.numberToHex(this.blue)}`;
   }
 }

--- a/src/api/style/FontFace.ts
+++ b/src/api/style/FontFace.ts
@@ -34,7 +34,7 @@ export class FontFace {
    *
    * @since 0.8.0
    */
-  public constructor (name: string, fontFamily?: string, fontPitch?: FontPitch) {
+  public constructor(name: string, fontFamily?: string, fontPitch?: FontPitch) {
     this.name = name;
     this.fontFamily = fontFamily;
     this.fontPitch = fontPitch;
@@ -57,8 +57,11 @@ export class FontFace {
    * @returns {FontFace} The `FontFace` object
    * @since 0.8.0
    */
-  public setCharset (fontCharset: string | undefined): FontFace {
-    if (fontCharset === undefined || /^[A-Za-z][A-Za-z0-9._-]*$/.test(fontCharset) === true) {
+  public setCharset(fontCharset: string | undefined): FontFace {
+    if (
+      fontCharset === undefined ||
+      /^[A-Za-z][A-Za-z0-9._-]*$/.test(fontCharset) === true
+    ) {
       this.fontCharset = fontCharset;
     }
 
@@ -77,7 +80,7 @@ export class FontFace {
    * @returns {string | undefined} The charset of the font or `undefined` if the charset is not set
    * @since 0.8.0
    */
-  public getCharset (): string | undefined {
+  public getCharset(): string | undefined {
     return this.fontCharset;
   }
 
@@ -93,7 +96,7 @@ export class FontFace {
    * @returns {FontFace} The `FontFace` object
    * @since 0.8.0
    */
-  public setFontFamily (fontFamily: string | undefined): FontFace {
+  public setFontFamily(fontFamily: string | undefined): FontFace {
     if (fontFamily === undefined || typeof fontFamily === 'string') {
       this.fontFamily = fontFamily;
     }
@@ -112,7 +115,7 @@ export class FontFace {
    * @returns {string | undefined} The font family of the font or `undefined` if the font family is not set
    * @since 0.8.0
    */
-  public getFontFamily (): string | undefined {
+  public getFontFamily(): string | undefined {
     return this.fontFamily;
   }
 
@@ -129,8 +132,13 @@ export class FontFace {
    * @returns {FontFace} The `FontFace` object
    * @since 0.8.0
    */
-  public setFontFamilyGeneric (fontFamilyGeneric: FontFamilyGeneric | undefined): FontFace {
-    if (fontFamilyGeneric === undefined || typeof fontFamilyGeneric === 'string') {
+  public setFontFamilyGeneric(
+    fontFamilyGeneric: FontFamilyGeneric | undefined
+  ): FontFace {
+    if (
+      fontFamilyGeneric === undefined ||
+      typeof fontFamilyGeneric === 'string'
+    ) {
       this.fontFamilyGeneric = fontFamilyGeneric;
     }
 
@@ -150,7 +158,7 @@ export class FontFace {
    *                               or `undefined` if the generic font family name is not set
    * @since 0.8.0
    */
-  public getFontFamilyGeneric (): FontFamilyGeneric | undefined {
+  public getFontFamilyGeneric(): FontFamilyGeneric | undefined {
     return this.fontFamilyGeneric;
   }
 
@@ -166,7 +174,7 @@ export class FontFace {
    * @returns {FontFace} The `FontFace` object
    * @since 0.8.0
    */
-  public setFontPitch (fontPitch: FontPitch | undefined): FontFace {
+  public setFontPitch(fontPitch: FontPitch | undefined): FontFace {
     this.fontPitch = fontPitch;
 
     return this;
@@ -184,7 +192,7 @@ export class FontFace {
    * @returns {string | undefined} The pitch of the font or `undefined` if the font pitch is not set
    * @since 0.8.0
    */
-  public getFontPitch (): FontPitch | undefined {
+  public getFontPitch(): FontPitch | undefined {
     return this.fontPitch;
   }
 
@@ -198,7 +206,7 @@ export class FontFace {
    * @returns {string} A string that identifies the font in this document
    * @since 0.8.0
    */
-  public getName (): string {
+  public getName(): string {
     return this.name;
   }
 }

--- a/src/api/style/FontFamilyGeneric.ts
+++ b/src/api/style/FontFamilyGeneric.ts
@@ -10,5 +10,5 @@ export enum FontFamilyGeneric {
   /** the family roman fonts (without serifs) */
   Swiss = 'swiss',
   /** the family system fonts */
-  System = 'system'
+  System = 'system',
 }

--- a/src/api/style/FontPitch.ts
+++ b/src/api/style/FontPitch.ts
@@ -1,4 +1,4 @@
 export enum FontPitch {
   Fixed = 'fixed',
-  Variable = 'variable'
+  Variable = 'variable',
 }

--- a/src/api/style/FontVariant.ts
+++ b/src/api/style/FontVariant.ts
@@ -1,4 +1,4 @@
 export enum FontVariant {
   Normal = 'normal',
-  SmallCaps = 'small-caps'
+  SmallCaps = 'small-caps',
 }

--- a/src/api/style/HorizontalAlignment.ts
+++ b/src/api/style/HorizontalAlignment.ts
@@ -3,5 +3,5 @@ export enum HorizontalAlignment {
   Left = 'left',
   Right = 'right',
   Center = 'center',
-  Justify = 'justify'
+  Justify = 'justify',
 }

--- a/src/api/style/HorizontalAlignmentLastLine.ts
+++ b/src/api/style/HorizontalAlignmentLastLine.ts
@@ -2,5 +2,5 @@ export enum HorizontalAlignmentLastLine {
   Default = '',
   Start = 'start',
   Center = 'center',
-  Justify = 'justify'
+  Justify = 'justify',
 }

--- a/src/api/style/IParagraphProperties.ts
+++ b/src/api/style/IParagraphProperties.ts
@@ -19,82 +19,82 @@ export interface IParagraphProperties {
   /**
    * @since 0.9.0
    */
-  setBackgroundColor (color: Color | undefined): void;
+  setBackgroundColor(color: Color | undefined): void;
 
   /**
    * @since 0.9.0
    */
-  getBackgroundColor (): Color | undefined;
+  getBackgroundColor(): Color | undefined;
 
   /**
    * @since 0.9.0
    */
-  setBorder (width: number, style: BorderStyle, color: Color): void;
+  setBorder(width: number, style: BorderStyle, color: Color): void;
 
   /**
    * @since 0.9.0
    */
-  removeBorder (): void;
+  removeBorder(): void;
 
   /**
    * @since 0.9.0
    */
-  setBorderBottom (width: number, style: BorderStyle, color: Color): void;
+  setBorderBottom(width: number, style: BorderStyle, color: Color): void;
 
   /**
    * @since 0.9.0
    */
-  getBorderBottom (): Border | undefined;
+  getBorderBottom(): Border | undefined;
 
   /**
    * @since 0.9.0
    */
-  removeBorderBottom (): void;
+  removeBorderBottom(): void;
 
   /**
    * @since 0.9.0
    */
-  setBorderLeft (width: number, style: BorderStyle, color: Color): void;
+  setBorderLeft(width: number, style: BorderStyle, color: Color): void;
 
   /**
    * @since 0.9.0
    */
-  getBorderLeft (): Border | undefined;
+  getBorderLeft(): Border | undefined;
 
   /**
    * @since 0.9.0
    */
-  removeBorderLeft (): void;
+  removeBorderLeft(): void;
 
   /**
    * @since 0.9.0
    */
-  setBorderRight (width: number, style: BorderStyle, color: Color): void;
+  setBorderRight(width: number, style: BorderStyle, color: Color): void;
 
   /**
    * @since 0.9.0
    */
-  getBorderRight (): Border | undefined;
+  getBorderRight(): Border | undefined;
 
   /**
    * @since 0.9.0
    */
-  removeBorderRight (): void;
+  removeBorderRight(): void;
 
   /**
    * @since 0.9.0
    */
-  setBorderTop (width: number, style: BorderStyle, color: Color): void;
+  setBorderTop(width: number, style: BorderStyle, color: Color): void;
 
   /**
    * @since 0.9.0
    */
-  getBorderTop (): Border | undefined;
+  getBorderTop(): Border | undefined;
 
   /**
    * @since 0.9.0
    */
-  removeBorderTop (): void;
+  removeBorderTop(): void;
 
   /**
    * Sets the horizontal alignment setting of this paragraph.
@@ -102,7 +102,7 @@ export interface IParagraphProperties {
    * @param {HorizontalAlignment} horizontalAlignment The horizontal alignment setting
    * @since 0.1.0
    */
-  setHorizontalAlignment (horizontalAlignment: HorizontalAlignment): void;
+  setHorizontalAlignment(horizontalAlignment: HorizontalAlignment): void;
 
   /**
    * Returns the horizontal alignment setting of this paragraph.
@@ -110,24 +110,26 @@ export interface IParagraphProperties {
    * @returns {HorizontalAlignment} The horizontal alignment setting
    * @since 0.2.0
    */
-  getHorizontalAlignment (): HorizontalAlignment;
+  getHorizontalAlignment(): HorizontalAlignment;
 
   /**
    * @since 0.9.0
    */
-  setHorizontalAlignmentLastLine (horizontalAlignment: HorizontalAlignmentLastLine): void;
+  setHorizontalAlignmentLastLine(
+    horizontalAlignment: HorizontalAlignmentLastLine
+  ): void;
 
   /**
    * @since 0.9.0
    */
-  getHorizontalAlignmentLastLine (): HorizontalAlignmentLastLine;
+  getHorizontalAlignmentLastLine(): HorizontalAlignmentLastLine;
 
   /**
    * Keeps paragraph lines on the same page (page break before paragraph if necessary).
    *
    * @since 0.6.0
    */
-  setKeepTogether (keepTogether?: boolean): void;
+  setKeepTogether(keepTogether?: boolean): void;
 
   /**
    * Returns whether the lines of the paragraph should be kept together.
@@ -135,147 +137,157 @@ export interface IParagraphProperties {
    * @returns {boolean} `true` if the paragraph lines should be kept together, `false` otherwise
    * @since 0.9.0
    */
-  getKeepTogether (): boolean;
+  getKeepTogether(): boolean;
 
   /**
    * @since 0.9.0
    */
-  setKeepWithNext (keepWithNext?: boolean): void;
+  setKeepWithNext(keepWithNext?: boolean): void;
 
   /**
    * @since 0.9.0
    */
-  getKeepWithNext (): boolean;
+  getKeepWithNext(): boolean;
 
   /**
    * @since 0.9.0
    */
-  setLineHeight (lineHeight: number | string | undefined): void;
+  setLineHeight(lineHeight: number | string | undefined): void;
 
   /**
    * @since 0.9.0
    */
-  getLineHeight (): number | string | undefined;
+  getLineHeight(): number | string | undefined;
 
   /**
    * @since 0.9.0
    */
-  setLineHeightAtLeast (minimumLineHeight: number | undefined): void;
+  setLineHeightAtLeast(minimumLineHeight: number | undefined): void;
 
   /**
    * @since 0.9.0
    */
-  getLineHeightAtLeast (): number | undefined;
+  getLineHeightAtLeast(): number | undefined;
 
   /**
    * @since 0.9.0
    */
-  setLineSpacing (lineSpacing: number | undefined): void;
+  setLineSpacing(lineSpacing: number | undefined): void;
 
   /**
    * @since 0.9.0
    */
-  getLineSpacing (): number | undefined;
+  getLineSpacing(): number | undefined;
 
   /**
    * @since 0.9.0
    */
-  setMargin (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void;
+  setMargin(
+    marginLeft: number,
+    marginRight: number,
+    marginTop: number,
+    marginBottom: number
+  ): void;
 
   /**
    * @since 0.9.0
    */
-  setMarginBottom (margin: number): void;
+  setMarginBottom(margin: number): void;
 
   /**
    * @since 0.9.0
    */
-  getMarginBottom (): number;
+  getMarginBottom(): number;
 
   /**
    * @since 0.9.0
    */
-  setMarginLeft (margin: number): void;
+  setMarginLeft(margin: number): void;
 
   /**
    * @since 0.9.0
    */
-  getMarginLeft (): number;
+  getMarginLeft(): number;
 
   /**
    * @since 0.9.0
    */
-  setMarginRight (margin: number): void;
+  setMarginRight(margin: number): void;
 
   /**
    * @since 0.9.0
    */
-  getMarginRight (): number;
+  getMarginRight(): number;
 
   /**
    * @since 0.9.0
    */
-  setMarginTop (margin: number): void;
+  setMarginTop(margin: number): void;
 
   /**
    * @since 0.9.0
    */
-  getMarginTop (): number;
+  getMarginTop(): number;
 
   /**
    * @since 0.9.0
    */
-  setOrphans (orphans: number | undefined): void;
+  setOrphans(orphans: number | undefined): void;
 
   /**
    * @since 0.9.0
    */
-  getOrphans (): number | undefined;
+  getOrphans(): number | undefined;
 
   /**
    * @since 0.9.0
    */
-  setPadding (paddingLeft: number, paddingRight: number, paddingTop: number, paddingBottom: number): void;
+  setPadding(
+    paddingLeft: number,
+    paddingRight: number,
+    paddingTop: number,
+    paddingBottom: number
+  ): void;
 
   /**
    * @since 0.9.0
    */
-  setPaddingBottom (padding: number): void;
+  setPaddingBottom(padding: number): void;
 
   /**
    * @since 0.9.0
    */
-  getPaddingBottom (): number;
+  getPaddingBottom(): number;
 
   /**
    * @since 0.9.0
    */
-  setPaddingLeft (padding: number): void;
+  setPaddingLeft(padding: number): void;
 
   /**
    * @since 0.9.0
    */
-  getPaddingLeft (): number;
+  getPaddingLeft(): number;
 
   /**
    * @since 0.9.0
    */
-  setPaddingRight (padding: number): void;
+  setPaddingRight(padding: number): void;
 
   /**
    * @since 0.9.0
    */
-  getPaddingRight (): number;
+  getPaddingRight(): number;
 
   /**
    * @since 0.9.0
    */
-  setPaddingTop (padding: number): void;
+  setPaddingTop(padding: number): void;
 
   /**
    * @since 0.9.0
    */
-  getPaddingTop (): number;
+  getPaddingTop(): number;
 
   /**
    * Sets the page break setting of the paragraph.
@@ -283,7 +295,7 @@ export interface IParagraphProperties {
    * @param {PageBreak} pageBreak The page break setting
    * @since 0.9.0
    */
-  setPageBreak (pageBreak: PageBreak): void;
+  setPageBreak(pageBreak: PageBreak): void;
 
   /**
    * Returns the page break setting of the paragraph.
@@ -291,37 +303,37 @@ export interface IParagraphProperties {
    * @returns {PageBreak} The page break setting
    * @since 0.9.0
    */
-  getPageBreak (): PageBreak;
+  getPageBreak(): PageBreak;
 
   /**
    * @since 0.9.0
    */
-  setTextIndent (textIndent: number): void;
+  setTextIndent(textIndent: number): void;
 
   /**
    * @since 0.9.0
    */
-  getTextIndent (): number;
+  getTextIndent(): number;
 
   /**
    * @since 0.9.0
    */
-  setVerticalAlignment (verticalAlignment: VerticalAlignment): void;
+  setVerticalAlignment(verticalAlignment: VerticalAlignment): void;
 
   /**
    * @since 0.9.0
    */
-  getVerticalAlignment (): VerticalAlignment;
+  getVerticalAlignment(): VerticalAlignment;
 
   /**
    * @since 0.9.0
    */
-  setWidows (widows: number | undefined): void;
+  setWidows(widows: number | undefined): void;
 
   /**
    * @since 0.9.0
    */
-  getWidows (): number | undefined;
+  getWidows(): number | undefined;
 
   /**
    * Adds a new tab stop to this style.
@@ -334,7 +346,7 @@ export interface IParagraphProperties {
    * or `undefined` if a tab stop at the same position already exists
    * @since 0.3.0
    */
-  addTabStop (position: number, type: TabStopType): TabStop | undefined;
+  addTabStop(position: number, type: TabStopType): TabStop | undefined;
 
   /**
    * Adds a new tab stop to this style.
@@ -346,7 +358,7 @@ export interface IParagraphProperties {
    * or `undefined` if a tab stop at the same position already exists
    * @since 0.3.0
    */
-  addTabStop (tabStop: TabStop): TabStop | undefined;
+  addTabStop(tabStop: TabStop): TabStop | undefined;
 
   /**
    * Returns all tab stops.
@@ -354,12 +366,12 @@ export interface IParagraphProperties {
    * @returns {TabStop[]} A copy of the list of tab stops
    * @since 0.3.0
    */
-  getTabStops (): TabStop[];
+  getTabStops(): TabStop[];
 
   /**
    * Removes all tab stops.
    *
    * @since 0.3.0
    */
-  clearTabStops (): void;
+  clearTabStops(): void;
 }

--- a/src/api/style/ITextProperties.ts
+++ b/src/api/style/ITextProperties.ts
@@ -33,12 +33,12 @@ export interface ITextProperties {
   /**
    * @since 0.9.0
    */
-  setBackgroundColor (color: Color | undefined): void;
+  setBackgroundColor(color: Color | undefined): void;
 
   /**
    * @since 0.9.0
    */
-  getBackgroundColor (): Color | undefined;
+  getBackgroundColor(): Color | undefined;
 
   /**
    * Sets the font color that will be applied to the text.
@@ -47,7 +47,7 @@ export interface ITextProperties {
    * @param {Color | undefined} color The font color to apply or `undefined` if the default color should be used
    * @since 0.4.0
    */
-  setColor (color: Color | undefined): void;
+  setColor(color: Color | undefined): void;
 
   /**
    * Returns the font color that will be applied to the text or `undefined` if the default color will be used.
@@ -55,7 +55,7 @@ export interface ITextProperties {
    * @returns {Color | undefined} The font color to apply or `undefined` if the default color will be used
    * @since 0.4.0
    */
-  getColor (): Color | undefined;
+  getColor(): Color | undefined;
 
   /**
    * Sets the name of the font that will be applied to the text.
@@ -64,7 +64,7 @@ export interface ITextProperties {
    * @param {string} name The name of the font to apply or `undefined` if the default font should be used
    * @since 0.4.0
    */
-  setFontName (name: string): void;
+  setFontName(name: string): void;
 
   /**
    * Returns the name of the font that will be applied to the text or `undefined` if the default font will be used.
@@ -72,7 +72,7 @@ export interface ITextProperties {
    * @returns {string | undefined} The name of the font to apply or `undefined` if the default font will be used
    * @since 0.4.0
    */
-  getFontName (): string | undefined;
+  getFontName(): string | undefined;
 
   /**
    * Sets the font size that will be applied to the text.
@@ -80,7 +80,7 @@ export interface ITextProperties {
    * @param {number} size The font size to apply as point value (pt)
    * @since 0.4.0
    */
-  setFontSize (size: number): void;
+  setFontSize(size: number): void;
 
   /**
    * Returns the font size that will be applied to the text.
@@ -88,17 +88,17 @@ export interface ITextProperties {
    * @returns {number} The font size to apply as point value (pt)
    * @since 0.4.0
    */
-  getFontSize (): number;
+  getFontSize(): number;
 
   /**
    * @since 0.9.0
    */
-  setFontVariant (fontVariant: FontVariant): void;
+  setFontVariant(fontVariant: FontVariant): void;
 
   /**
    * @since 0.9.0
    */
-  getFontVariant (): FontVariant;
+  getFontVariant(): FontVariant;
 
   /**
    * Sets the transformation that will be applied to the text.
@@ -106,7 +106,7 @@ export interface ITextProperties {
    * @param {TextTransformation} transformation The transformation to apply
    * @since 0.4.0
    */
-  setTextTransformation (transformation: TextTransformation): void;
+  setTextTransformation(transformation: TextTransformation): void;
 
   /**
    * Returns the transformation that will be applied to the text.
@@ -114,7 +114,7 @@ export interface ITextProperties {
    * @returns {TextTransformation} The transformation to apply
    * @since 0.4.0
    */
-  getTextTransformation (): TextTransformation;
+  getTextTransformation(): TextTransformation;
 
   /**
    * Sets the typeface that will be applied to the text.
@@ -122,7 +122,7 @@ export interface ITextProperties {
    * @param {Typeface} typeface The typeface to apply
    * @since 0.4.0
    */
-  setTypeface (typeface: Typeface): void;
+  setTypeface(typeface: Typeface): void;
 
   /**
    * Returns the typeface that will be applied to the text.
@@ -130,5 +130,5 @@ export interface ITextProperties {
    * @returns {Typeface} The typeface to apply
    * @since 0.4.0
    */
-  getTypeface (): Typeface;
+  getTypeface(): Typeface;
 }

--- a/src/api/style/PageBreak.ts
+++ b/src/api/style/PageBreak.ts
@@ -1,5 +1,5 @@
 export enum PageBreak {
   None,
   Before,
-  After
+  After,
 }

--- a/src/api/style/ParagraphProperties.spec.ts
+++ b/src/api/style/ParagraphProperties.spec.ts
@@ -37,7 +37,7 @@ describe(ParagraphProperties.name, () => {
     const expectedBorder: Border = {
       width: testBorderWidth,
       style: testBorderStyle,
-      color: testBorderColor
+      color: testBorderColor,
     };
 
     it('return undefined by default', () => {
@@ -48,10 +48,26 @@ describe(ParagraphProperties.name, () => {
     });
 
     it('return previously set border', () => {
-      const expectedBorderBottom: Border = { width: 0.23, style: BorderStyle.Dashed, color: testBorderColor };
-      const expectedBorderLeft: Border = { width: 13.37, style: BorderStyle.Dotted, color: testBorderColor };
-      const expectedBorderRight: Border = { width: 42.24, style: BorderStyle.Double, color: testBorderColor };
-      const expectedBorderTop: Border = { width: 12.34, style: BorderStyle.Solid, color: testBorderColor };
+      const expectedBorderBottom: Border = {
+        width: 0.23,
+        style: BorderStyle.Dashed,
+        color: testBorderColor,
+      };
+      const expectedBorderLeft: Border = {
+        width: 13.37,
+        style: BorderStyle.Dotted,
+        color: testBorderColor,
+      };
+      const expectedBorderRight: Border = {
+        width: 42.24,
+        style: BorderStyle.Double,
+        color: testBorderColor,
+      };
+      const expectedBorderTop: Border = {
+        width: 12.34,
+        style: BorderStyle.Solid,
+        color: testBorderColor,
+      };
 
       properties.setBorderBottom(0.23, BorderStyle.Dashed, testBorderColor);
       properties.setBorderLeft(13.37, BorderStyle.Dotted, testBorderColor);
@@ -74,10 +90,26 @@ describe(ParagraphProperties.name, () => {
     });
 
     it('ignore invalid value', () => {
-      properties.setBorderBottom(testBorderWidth, testBorderStyle, testBorderColor);
-      properties.setBorderLeft(testBorderWidth, testBorderStyle, testBorderColor);
-      properties.setBorderRight(testBorderWidth, testBorderStyle, testBorderColor);
-      properties.setBorderTop(testBorderWidth, testBorderStyle, testBorderColor);
+      properties.setBorderBottom(
+        testBorderWidth,
+        testBorderStyle,
+        testBorderColor
+      );
+      properties.setBorderLeft(
+        testBorderWidth,
+        testBorderStyle,
+        testBorderColor
+      );
+      properties.setBorderRight(
+        testBorderWidth,
+        testBorderStyle,
+        testBorderColor
+      );
+      properties.setBorderTop(
+        testBorderWidth,
+        testBorderStyle,
+        testBorderColor
+      );
 
       properties.setBorderBottom(-0.1, testBorderStyle, testBorderColor);
       properties.setBorderLeft(-0.1, testBorderStyle, testBorderColor);
@@ -118,25 +150,35 @@ describe(ParagraphProperties.name, () => {
 
   describe('horizontal alignment', () => {
     it('return `Default` by default', () => {
-      expect(properties.getHorizontalAlignment()).toBe(HorizontalAlignment.Default);
+      expect(properties.getHorizontalAlignment()).toBe(
+        HorizontalAlignment.Default
+      );
     });
 
     it('return previously set alignment', () => {
       properties.setHorizontalAlignment(HorizontalAlignment.Center);
 
-      expect(properties.getHorizontalAlignment()).toBe(HorizontalAlignment.Center);
+      expect(properties.getHorizontalAlignment()).toBe(
+        HorizontalAlignment.Center
+      );
     });
   });
 
   describe('horizontal alignment last line', () => {
     it('return `Default` by default', () => {
-      expect(properties.getHorizontalAlignmentLastLine()).toBe(HorizontalAlignment.Default);
+      expect(properties.getHorizontalAlignmentLastLine()).toBe(
+        HorizontalAlignment.Default
+      );
     });
 
     it('return previously set alignment', () => {
-      properties.setHorizontalAlignmentLastLine(HorizontalAlignmentLastLine.Center);
+      properties.setHorizontalAlignmentLastLine(
+        HorizontalAlignmentLastLine.Center
+      );
 
-      expect(properties.getHorizontalAlignmentLastLine()).toBe(HorizontalAlignmentLastLine.Center);
+      expect(properties.getHorizontalAlignmentLastLine()).toBe(
+        HorizontalAlignmentLastLine.Center
+      );
     });
   });
 
@@ -277,7 +319,12 @@ describe(ParagraphProperties.name, () => {
     });
 
     it('return previously set margin (set once)', () => {
-      properties.setMargin(testMarginLeft, testMarginRight, testMarginTop, testMarginBottom);
+      properties.setMargin(
+        testMarginLeft,
+        testMarginRight,
+        testMarginTop,
+        testMarginBottom
+      );
 
       expect(properties.getMarginBottom()).toBe(testMarginBottom);
       expect(properties.getMarginLeft()).toBe(testMarginLeft);
@@ -355,7 +402,12 @@ describe(ParagraphProperties.name, () => {
     });
 
     it('return previously set padding (set once)', () => {
-      properties.setPadding(testPaddingLeft, testPaddingRight, testPaddingTop, testPaddingBottom);
+      properties.setPadding(
+        testPaddingLeft,
+        testPaddingRight,
+        testPaddingTop,
+        testPaddingBottom
+      );
 
       expect(properties.getPaddingBottom()).toBe(testPaddingBottom);
       expect(properties.getPaddingLeft()).toBe(testPaddingLeft);

--- a/src/api/style/ParagraphProperties.ts
+++ b/src/api/style/ParagraphProperties.ts
@@ -39,7 +39,7 @@ export class ParagraphProperties implements IParagraphProperties {
   private widows: number | undefined;
   private tabStops: TabStop[] = [];
 
-  public constructor () {
+  public constructor() {
     this.horizontalAlignment = HorizontalAlignment.Default;
     this.horizontalAlignmentLastLine = HorizontalAlignmentLastLine.Default;
     this.marginBottom = 0;
@@ -58,17 +58,17 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public setBackgroundColor (color: Color | undefined): void {
+  public setBackgroundColor(color: Color | undefined): void {
     this.backgroundColor = color;
   }
 
   /** @inheritdoc */
-  public getBackgroundColor (): Color | undefined {
+  public getBackgroundColor(): Color | undefined {
     return this.backgroundColor;
   }
 
   /** @inheritdoc */
-  public setBorder (width: number, style: BorderStyle, color: Color): void {
+  public setBorder(width: number, style: BorderStyle, color: Color): void {
     this.setBorderBottom(width, style, color);
     this.setBorderLeft(width, style, color);
     this.setBorderRight(width, style, color);
@@ -76,7 +76,7 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public removeBorder (): void {
+  public removeBorder(): void {
     this.removeBorderBottom();
     this.removeBorderLeft();
     this.removeBorderRight();
@@ -84,193 +84,213 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public setBorderBottom (width: number, style: BorderStyle, color: Color): void {
+  public setBorderBottom(
+    width: number,
+    style: BorderStyle,
+    color: Color
+  ): void {
     if (isNonNegativeNumber(width)) {
       this.borderBottom = { width, style, color };
     }
   }
 
   /** @inheritdoc */
-  public getBorderBottom (): Border | undefined {
+  public getBorderBottom(): Border | undefined {
     return this.borderBottom;
   }
 
   /** @inheritdoc */
-  public removeBorderBottom (): void {
+  public removeBorderBottom(): void {
     this.borderBottom = undefined;
   }
 
   /** @inheritdoc */
-  public setBorderLeft (width: number, style: BorderStyle, color: Color): void {
+  public setBorderLeft(width: number, style: BorderStyle, color: Color): void {
     if (isNonNegativeNumber(width)) {
       this.borderLeft = { width, style, color };
     }
   }
 
   /** @inheritdoc */
-  public getBorderLeft (): Border | undefined {
+  public getBorderLeft(): Border | undefined {
     return this.borderLeft;
   }
 
   /** @inheritdoc */
-  public removeBorderLeft (): void {
+  public removeBorderLeft(): void {
     this.borderLeft = undefined;
   }
 
   /** @inheritdoc */
-  public setBorderRight (width: number, style: BorderStyle, color: Color): void {
+  public setBorderRight(width: number, style: BorderStyle, color: Color): void {
     if (isNonNegativeNumber(width)) {
       this.borderRight = { width, style, color };
     }
   }
 
   /** @inheritdoc */
-  public getBorderRight (): Border | undefined {
+  public getBorderRight(): Border | undefined {
     return this.borderRight;
   }
 
   /** @inheritdoc */
-  public removeBorderRight (): void {
+  public removeBorderRight(): void {
     this.borderRight = undefined;
   }
 
   /** @inheritdoc */
-  public setBorderTop (width: number, style: BorderStyle, color: Color): void {
+  public setBorderTop(width: number, style: BorderStyle, color: Color): void {
     if (isNonNegativeNumber(width)) {
       this.borderTop = { width, style, color };
     }
   }
 
   /** @inheritdoc */
-  public getBorderTop (): Border | undefined {
+  public getBorderTop(): Border | undefined {
     return this.borderTop;
   }
 
   /** @inheritdoc */
-  public removeBorderTop (): void {
+  public removeBorderTop(): void {
     this.borderTop = undefined;
   }
 
   /** @inheritdoc */
-  public setHorizontalAlignment (horizontalAlignment: HorizontalAlignment): void {
+  public setHorizontalAlignment(
+    horizontalAlignment: HorizontalAlignment
+  ): void {
     this.horizontalAlignment = horizontalAlignment;
   }
 
   /** @inheritdoc */
-  public getHorizontalAlignment (): HorizontalAlignment {
+  public getHorizontalAlignment(): HorizontalAlignment {
     return this.horizontalAlignment;
   }
 
   /** @inheritdoc */
-  public setHorizontalAlignmentLastLine (horizontalAlignment: HorizontalAlignmentLastLine): void {
+  public setHorizontalAlignmentLastLine(
+    horizontalAlignment: HorizontalAlignmentLastLine
+  ): void {
     this.horizontalAlignmentLastLine = horizontalAlignment;
   }
 
   /** @inheritdoc */
-  public getHorizontalAlignmentLastLine (): HorizontalAlignmentLastLine {
+  public getHorizontalAlignmentLastLine(): HorizontalAlignmentLastLine {
     return this.horizontalAlignmentLastLine;
   }
 
   /** @inheritdoc */
-  public setKeepTogether (keepTogether = true): void {
+  public setKeepTogether(keepTogether = true): void {
     this.shouldKeepTogether = keepTogether;
   }
 
   /** @inheritdoc */
-  public getKeepTogether (): boolean {
+  public getKeepTogether(): boolean {
     return this.shouldKeepTogether;
   }
 
   /** @inheritdoc */
-  public setKeepWithNext (keepWithNext = true): void {
+  public setKeepWithNext(keepWithNext = true): void {
     this.shouldKeepWithNext = keepWithNext;
   }
 
   /** @inheritdoc */
-  public getKeepWithNext (): boolean {
+  public getKeepWithNext(): boolean {
     return this.shouldKeepWithNext;
   }
 
   /** @inheritdoc */
-  public setLineHeight (lineHeight: number | string | undefined): void {
-    if (isNonNegativeNumber(lineHeight) || isPercent(lineHeight) || lineHeight === undefined) {
+  public setLineHeight(lineHeight: number | string | undefined): void {
+    if (
+      isNonNegativeNumber(lineHeight) ||
+      isPercent(lineHeight) ||
+      lineHeight === undefined
+    ) {
       this.lineHeight = lineHeight;
     }
   }
 
   /** @inheritdoc */
-  public getLineHeight (): number | string | undefined {
+  public getLineHeight(): number | string | undefined {
     return this.lineHeight;
   }
 
   /** @inheritdoc */
-  public setLineHeightAtLeast (minimumLineHeight: number | undefined): void {
-    if (isNonNegativeNumber(minimumLineHeight) || minimumLineHeight === undefined) {
+  public setLineHeightAtLeast(minimumLineHeight: number | undefined): void {
+    if (
+      isNonNegativeNumber(minimumLineHeight) ||
+      minimumLineHeight === undefined
+    ) {
       this.minimumLineHeight = minimumLineHeight;
     }
   }
 
   /** @inheritdoc */
-  public getLineHeightAtLeast (): number | undefined {
+  public getLineHeightAtLeast(): number | undefined {
     return this.minimumLineHeight;
   }
 
   /** @inheritdoc */
-  public setLineSpacing (lineSpacing: number | undefined): void {
+  public setLineSpacing(lineSpacing: number | undefined): void {
     this.lineSpacing = lineSpacing;
   }
 
   /** @inheritdoc */
-  public getLineSpacing (): number | undefined {
+  public getLineSpacing(): number | undefined {
     return this.lineSpacing;
   }
 
   /** @inheritdoc */
-  public setMarginBottom (margin: number): void {
+  public setMarginBottom(margin: number): void {
     if (isNonNegativeNumber(margin)) {
       this.marginBottom = margin;
     }
   }
 
   /** @inheritdoc */
-  public getMarginBottom (): number {
+  public getMarginBottom(): number {
     return this.marginBottom;
   }
 
   /** @inheritdoc */
-  public setMarginLeft (margin: number): void {
+  public setMarginLeft(margin: number): void {
     this.marginLeft = margin;
   }
 
   /** @inheritdoc */
-  public getMarginLeft (): number {
+  public getMarginLeft(): number {
     return this.marginLeft;
   }
 
   /** @inheritdoc */
-  public setMarginRight (margin: number): void {
+  public setMarginRight(margin: number): void {
     this.marginRight = margin;
   }
 
   /** @inheritdoc */
-  public getMarginRight (): number {
+  public getMarginRight(): number {
     return this.marginRight;
   }
 
   /** @inheritdoc */
-  public setMarginTop (margin: number): void {
+  public setMarginTop(margin: number): void {
     if (isNonNegativeNumber(margin)) {
       this.marginTop = margin;
     }
   }
 
   /** @inheritdoc */
-  public getMarginTop (): number {
+  public getMarginTop(): number {
     return this.marginTop;
   }
 
   /** @inheritdoc */
-  public setMargin (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): void {
+  public setMargin(
+    marginLeft: number,
+    marginRight: number,
+    marginTop: number,
+    marginBottom: number
+  ): void {
     this.setMarginLeft(marginLeft);
     this.setMarginRight(marginRight);
     this.setMarginTop(marginTop);
@@ -278,7 +298,7 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public setOrphans (orphans: number | undefined): void {
+  public setOrphans(orphans: number | undefined): void {
     if (isNonNegativeNumber(orphans)) {
       this.orphans = Math.trunc(orphans as number);
       return;
@@ -290,60 +310,65 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public getOrphans (): number | undefined {
+  public getOrphans(): number | undefined {
     return this.orphans;
   }
 
   /** @inheritdoc */
-  public setPaddingBottom (padding: number): void {
+  public setPaddingBottom(padding: number): void {
     if (isNonNegativeNumber(padding)) {
       this.paddingBottom = padding;
     }
   }
 
   /** @inheritdoc */
-  public getPaddingBottom (): number {
+  public getPaddingBottom(): number {
     return this.paddingBottom;
   }
 
   /** @inheritdoc */
-  public setPaddingLeft (padding: number): void {
+  public setPaddingLeft(padding: number): void {
     if (isNonNegativeNumber(padding)) {
       this.paddingLeft = padding;
     }
   }
 
   /** @inheritdoc */
-  public getPaddingLeft (): number {
+  public getPaddingLeft(): number {
     return this.paddingLeft;
   }
 
   /** @inheritdoc */
-  public setPaddingRight (padding: number): void {
+  public setPaddingRight(padding: number): void {
     if (isNonNegativeNumber(padding)) {
       this.paddingRight = padding;
     }
   }
 
   /** @inheritdoc */
-  public getPaddingRight (): number {
+  public getPaddingRight(): number {
     return this.paddingRight;
   }
 
   /** @inheritdoc */
-  public setPaddingTop (padding: number): void {
+  public setPaddingTop(padding: number): void {
     if (isNonNegativeNumber(padding)) {
       this.paddingTop = padding;
     }
   }
 
   /** @inheritdoc */
-  public getPaddingTop (): number {
+  public getPaddingTop(): number {
     return this.paddingTop;
   }
 
   /** @inheritdoc */
-  public setPadding (paddingLeft: number, paddingRight: number, paddingTop: number, paddingBottom: number): void {
+  public setPadding(
+    paddingLeft: number,
+    paddingRight: number,
+    paddingTop: number,
+    paddingBottom: number
+  ): void {
     this.setPaddingLeft(paddingLeft);
     this.setPaddingRight(paddingRight);
     this.setPaddingTop(paddingTop);
@@ -351,37 +376,37 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public setPageBreak (pageBreak: PageBreak): void {
+  public setPageBreak(pageBreak: PageBreak): void {
     this.pageBreak = pageBreak;
   }
 
   /** @inheritdoc */
-  public getPageBreak (): PageBreak {
+  public getPageBreak(): PageBreak {
     return this.pageBreak;
   }
 
   /** @inheritdoc */
-  public setTextIndent (textIndent: number): void {
+  public setTextIndent(textIndent: number): void {
     this.textIndent = textIndent;
   }
 
   /** @inheritdoc */
-  public getTextIndent (): number {
+  public getTextIndent(): number {
     return this.textIndent;
   }
 
   /** @inheritdoc */
-  public setVerticalAlignment (verticalAlignment: VerticalAlignment): void {
+  public setVerticalAlignment(verticalAlignment: VerticalAlignment): void {
     this.verticalAlignment = verticalAlignment;
   }
 
   /** @inheritdoc */
-  public getVerticalAlignment (): VerticalAlignment {
+  public getVerticalAlignment(): VerticalAlignment {
     return this.verticalAlignment;
   }
 
   /** @inheritdoc */
-  public setWidows (widows: number | undefined): void {
+  public setWidows(widows: number | undefined): void {
     if (isNonNegativeNumber(widows)) {
       this.widows = Math.trunc(widows as number);
       return;
@@ -393,17 +418,21 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public getWidows (): number | undefined {
+  public getWidows(): number | undefined {
     return this.widows;
   }
 
   /** @inheritdoc */
-  public addTabStop (position: number, type: TabStopType): TabStop | undefined;
+  public addTabStop(position: number, type: TabStopType): TabStop | undefined;
 
   /** @inheritDoc */
-  public addTabStop (tabStop: TabStop): TabStop | undefined;
-  public addTabStop (arg1: number | TabStop, type = TabStopType.Left): TabStop | undefined {
-    const newTabStop = typeof arg1 === 'object' ? arg1 : new TabStop(arg1, type);
+  public addTabStop(tabStop: TabStop): TabStop | undefined;
+  public addTabStop(
+    arg1: number | TabStop,
+    type = TabStopType.Left
+  ): TabStop | undefined {
+    const newTabStop =
+      typeof arg1 === 'object' ? arg1 : new TabStop(arg1, type);
 
     const existsTabStop = this.tabStops.some((value: TabStop) => {
       return newTabStop.getPosition() === value.getPosition();
@@ -420,19 +449,19 @@ export class ParagraphProperties implements IParagraphProperties {
   }
 
   /** @inheritdoc */
-  public getTabStops (): TabStop[] {
+  public getTabStops(): TabStop[] {
     return Array.from(this.tabStops);
   }
 
   /** @inheritdoc */
-  public clearTabStops (): void {
+  public clearTabStops(): void {
     this.tabStops = [];
   }
 
   /**
    * Sorts the tab stops by their position ascending.
    */
-  private sortTabStops (): void {
+  private sortTabStops(): void {
     this.tabStops.sort((a: TabStop, b: TabStop) => {
       return a.getPosition() - b.getPosition();
     });

--- a/src/api/style/ParagraphStyle.ts
+++ b/src/api/style/ParagraphStyle.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-dupe-class-members */
 import { Border } from './Border';
 import { BorderStyle } from './BorderStyle';
 import { Color } from './Color';
@@ -18,11 +17,12 @@ import { TextTransformation } from './TextTransformation';
 import { Typeface } from './Typeface';
 import { VerticalAlignment } from './VerticalAlignment';
 
-export class ParagraphStyle extends Style implements IParagraphProperties, ITextProperties {
+export class ParagraphStyle extends Style
+  implements IParagraphProperties, ITextProperties {
   private paragraphProperties: ParagraphProperties;
   private textProperties: TextProperties;
 
-  public constructor (name: string = Style.UNNAMED) {
+  public constructor(name: string = Style.UNNAMED) {
     super(name, StyleFamily.Paragraph);
 
     this.paragraphProperties = new ParagraphProperties();
@@ -32,381 +32,432 @@ export class ParagraphStyle extends Style implements IParagraphProperties, IText
   // paragraph properties
 
   /** @inheritdoc */
-  public setBackgroundColor (color: Color | undefined): ParagraphStyle {
+  public setBackgroundColor(color: Color | undefined): ParagraphStyle {
     this.paragraphProperties.setBackgroundColor(color);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getBackgroundColor (): Color | undefined {
+  public getBackgroundColor(): Color | undefined {
     return this.paragraphProperties.getBackgroundColor();
   }
 
   /** @inheritdoc */
-  public setBorder (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+  public setBorder(
+    width: number,
+    style: BorderStyle,
+    color: Color
+  ): ParagraphStyle {
     this.paragraphProperties.setBorder(width, style, color);
 
     return this;
   }
 
   /** @inheritdoc */
-  public removeBorder (): ParagraphStyle {
+  public removeBorder(): ParagraphStyle {
     this.paragraphProperties.removeBorder();
 
     return this;
   }
 
   /** @inheritdoc */
-  public setBorderBottom (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+  public setBorderBottom(
+    width: number,
+    style: BorderStyle,
+    color: Color
+  ): ParagraphStyle {
     this.paragraphProperties.setBorderBottom(width, style, color);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getBorderBottom (): Border | undefined {
+  public getBorderBottom(): Border | undefined {
     return this.paragraphProperties.getBorderBottom();
   }
 
   /** @inheritdoc */
-  public removeBorderBottom (): ParagraphStyle {
+  public removeBorderBottom(): ParagraphStyle {
     this.paragraphProperties.removeBorderBottom();
 
     return this;
   }
 
   /** @inheritdoc */
-  public setBorderLeft (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+  public setBorderLeft(
+    width: number,
+    style: BorderStyle,
+    color: Color
+  ): ParagraphStyle {
     this.paragraphProperties.setBorderLeft(width, style, color);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getBorderLeft (): Border | undefined {
+  public getBorderLeft(): Border | undefined {
     return this.paragraphProperties.getBorderLeft();
   }
 
   /** @inheritdoc */
-  public removeBorderLeft (): ParagraphStyle {
+  public removeBorderLeft(): ParagraphStyle {
     this.paragraphProperties.removeBorderLeft();
 
     return this;
   }
 
   /** @inheritdoc */
-  public setBorderRight (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+  public setBorderRight(
+    width: number,
+    style: BorderStyle,
+    color: Color
+  ): ParagraphStyle {
     this.paragraphProperties.setBorderRight(width, style, color);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getBorderRight (): Border | undefined {
+  public getBorderRight(): Border | undefined {
     return this.paragraphProperties.getBorderRight();
   }
 
   /** @inheritdoc */
-  public removeBorderRight (): ParagraphStyle {
+  public removeBorderRight(): ParagraphStyle {
     this.paragraphProperties.removeBorderRight();
 
     return this;
   }
 
   /** @inheritdoc */
-  public setBorderTop (width: number, style: BorderStyle, color: Color): ParagraphStyle {
+  public setBorderTop(
+    width: number,
+    style: BorderStyle,
+    color: Color
+  ): ParagraphStyle {
     this.paragraphProperties.setBorderTop(width, style, color);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getBorderTop (): Border | undefined {
+  public getBorderTop(): Border | undefined {
     return this.paragraphProperties.getBorderTop();
   }
 
   /** @inheritdoc */
-  public removeBorderTop (): ParagraphStyle {
+  public removeBorderTop(): ParagraphStyle {
     this.paragraphProperties.removeBorderTop();
 
     return this;
   }
 
   /** @inheritdoc */
-  public setHorizontalAlignment (horizontalAlignment: HorizontalAlignment): ParagraphStyle {
+  public setHorizontalAlignment(
+    horizontalAlignment: HorizontalAlignment
+  ): ParagraphStyle {
     this.paragraphProperties.setHorizontalAlignment(horizontalAlignment);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getHorizontalAlignment (): HorizontalAlignment {
+  public getHorizontalAlignment(): HorizontalAlignment {
     return this.paragraphProperties.getHorizontalAlignment();
   }
 
   /** @inheritdoc */
-  public setHorizontalAlignmentLastLine (horizontalAlignment: HorizontalAlignmentLastLine): ParagraphStyle {
-    this.paragraphProperties.setHorizontalAlignmentLastLine(horizontalAlignment);
+  public setHorizontalAlignmentLastLine(
+    horizontalAlignment: HorizontalAlignmentLastLine
+  ): ParagraphStyle {
+    this.paragraphProperties.setHorizontalAlignmentLastLine(
+      horizontalAlignment
+    );
 
     return this;
   }
 
   /** @inheritdoc */
-  public getHorizontalAlignmentLastLine (): HorizontalAlignmentLastLine {
+  public getHorizontalAlignmentLastLine(): HorizontalAlignmentLastLine {
     return this.paragraphProperties.getHorizontalAlignmentLastLine();
   }
 
   /** @inheritdoc */
-  public setKeepTogether (keepTogether = true): ParagraphStyle {
+  public setKeepTogether(keepTogether = true): ParagraphStyle {
     this.paragraphProperties.setKeepTogether(keepTogether);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getKeepTogether (): boolean {
+  public getKeepTogether(): boolean {
     return this.paragraphProperties.getKeepTogether();
   }
 
   /** @inheritdoc */
-  public setKeepWithNext (keepWithNext = true): ParagraphStyle {
+  public setKeepWithNext(keepWithNext = true): ParagraphStyle {
     this.paragraphProperties.setKeepWithNext(keepWithNext);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getKeepWithNext (): boolean {
+  public getKeepWithNext(): boolean {
     return this.paragraphProperties.getKeepWithNext();
   }
 
   /** @inheritdoc */
-  public setLineHeight (lineHeight: number | string | undefined): ParagraphStyle {
+  public setLineHeight(
+    lineHeight: number | string | undefined
+  ): ParagraphStyle {
     this.paragraphProperties.setLineHeight(lineHeight);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getLineHeight (): number | string | undefined {
+  public getLineHeight(): number | string | undefined {
     return this.paragraphProperties.getLineHeight();
   }
 
   /** @inheritdoc */
-  public setLineHeightAtLeast (minimumLineHeight: number | undefined): ParagraphStyle {
+  public setLineHeightAtLeast(
+    minimumLineHeight: number | undefined
+  ): ParagraphStyle {
     this.paragraphProperties.setLineHeightAtLeast(minimumLineHeight);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getLineHeightAtLeast (): number | undefined {
+  public getLineHeightAtLeast(): number | undefined {
     return this.paragraphProperties.getLineHeightAtLeast();
   }
 
   /** @inheritdoc */
-  public setLineSpacing (lineSpacing: number | undefined): ParagraphStyle {
+  public setLineSpacing(lineSpacing: number | undefined): ParagraphStyle {
     this.paragraphProperties.setLineSpacing(lineSpacing);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getLineSpacing (): number | undefined {
+  public getLineSpacing(): number | undefined {
     return this.paragraphProperties.getLineSpacing();
   }
 
   /** @inheritdoc */
-  public setMarginBottom (margin: number): ParagraphStyle {
+  public setMarginBottom(margin: number): ParagraphStyle {
     this.paragraphProperties.setMarginBottom(margin);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getMarginBottom (): number {
+  public getMarginBottom(): number {
     return this.paragraphProperties.getMarginBottom();
   }
 
   /** @inheritdoc */
-  public setMarginLeft (margin: number): ParagraphStyle {
+  public setMarginLeft(margin: number): ParagraphStyle {
     this.paragraphProperties.setMarginLeft(margin);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getMarginLeft (): number {
+  public getMarginLeft(): number {
     return this.paragraphProperties.getMarginLeft();
   }
 
   /** @inheritdoc */
-  public setMarginRight (margin: number): ParagraphStyle {
+  public setMarginRight(margin: number): ParagraphStyle {
     this.paragraphProperties.setMarginRight(margin);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getMarginRight (): number {
+  public getMarginRight(): number {
     return this.paragraphProperties.getMarginRight();
   }
 
   /** @inheritdoc */
-  public setMarginTop (margin: number): ParagraphStyle {
+  public setMarginTop(margin: number): ParagraphStyle {
     this.paragraphProperties.setMarginTop(margin);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getMarginTop (): number {
+  public getMarginTop(): number {
     return this.paragraphProperties.getMarginTop();
   }
 
   /** @inheritdoc */
-  public setMargin (marginLeft: number, marginRight: number, marginTop: number, marginBottom: number): ParagraphStyle {
-    this.paragraphProperties.setMargin(marginLeft, marginRight, marginTop, marginBottom);
+  public setMargin(
+    marginLeft: number,
+    marginRight: number,
+    marginTop: number,
+    marginBottom: number
+  ): ParagraphStyle {
+    this.paragraphProperties.setMargin(
+      marginLeft,
+      marginRight,
+      marginTop,
+      marginBottom
+    );
 
     return this;
   }
 
   /** @inheritdoc */
-  public setOrphans (orphans: number | undefined): ParagraphStyle {
+  public setOrphans(orphans: number | undefined): ParagraphStyle {
     this.paragraphProperties.setOrphans(orphans);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getOrphans (): number | undefined {
+  public getOrphans(): number | undefined {
     return this.paragraphProperties.getOrphans();
   }
 
   /** @inheritdoc */
-  public setPaddingBottom (padding: number): ParagraphStyle {
+  public setPaddingBottom(padding: number): ParagraphStyle {
     this.paragraphProperties.setPaddingBottom(padding);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getPaddingBottom (): number {
+  public getPaddingBottom(): number {
     return this.paragraphProperties.getPaddingBottom();
   }
 
   /** @inheritdoc */
-  public setPaddingLeft (padding: number): ParagraphStyle {
+  public setPaddingLeft(padding: number): ParagraphStyle {
     this.paragraphProperties.setPaddingLeft(padding);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getPaddingLeft (): number {
+  public getPaddingLeft(): number {
     return this.paragraphProperties.getPaddingLeft();
   }
 
   /** @inheritdoc */
-  public setPaddingRight (padding: number): ParagraphStyle {
+  public setPaddingRight(padding: number): ParagraphStyle {
     this.paragraphProperties.setPaddingRight(padding);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getPaddingRight (): number {
+  public getPaddingRight(): number {
     return this.paragraphProperties.getPaddingRight();
   }
 
   /** @inheritdoc */
-  public setPaddingTop (padding: number): ParagraphStyle {
+  public setPaddingTop(padding: number): ParagraphStyle {
     this.paragraphProperties.setPaddingTop(padding);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getPaddingTop (): number {
+  public getPaddingTop(): number {
     return this.paragraphProperties.getPaddingTop();
   }
 
   /** @inheritdoc */
-  public setPadding (
+  public setPadding(
     paddingLeft: number,
     paddingRight: number,
     paddingTop: number,
-    paddingBottom: number): ParagraphStyle {
-    this.paragraphProperties.setPadding(paddingLeft, paddingRight, paddingTop, paddingBottom);
+    paddingBottom: number
+  ): ParagraphStyle {
+    this.paragraphProperties.setPadding(
+      paddingLeft,
+      paddingRight,
+      paddingTop,
+      paddingBottom
+    );
 
     return this;
   }
 
   /** @inheritdoc */
-  public setPageBreak (pageBreak: PageBreak): ParagraphStyle {
+  public setPageBreak(pageBreak: PageBreak): ParagraphStyle {
     this.paragraphProperties.setPageBreak(pageBreak);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getPageBreak (): PageBreak {
+  public getPageBreak(): PageBreak {
     return this.paragraphProperties.getPageBreak();
   }
 
   /** @inheritdoc */
-  public setTextIndent (textIndent: number): ParagraphStyle {
+  public setTextIndent(textIndent: number): ParagraphStyle {
     this.paragraphProperties.setTextIndent(textIndent);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getTextIndent (): number {
+  public getTextIndent(): number {
     return this.paragraphProperties.getTextIndent();
   }
 
   /** @inheritdoc */
-  public setVerticalAlignment (verticalAlignment: VerticalAlignment): ParagraphStyle {
+  public setVerticalAlignment(
+    verticalAlignment: VerticalAlignment
+  ): ParagraphStyle {
     this.paragraphProperties.setVerticalAlignment(verticalAlignment);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getVerticalAlignment (): VerticalAlignment {
+  public getVerticalAlignment(): VerticalAlignment {
     return this.paragraphProperties.getVerticalAlignment();
   }
 
   /** @inheritdoc */
-  public setWidows (widows: number | undefined): ParagraphStyle {
+  public setWidows(widows: number | undefined): ParagraphStyle {
     this.paragraphProperties.setWidows(widows);
 
     return this;
   }
 
   /** @inheritdoc */
-  public getWidows (): number | undefined {
+  public getWidows(): number | undefined {
     return this.paragraphProperties.getWidows();
   }
 
   /** @inheritdoc */
-  public addTabStop (position: number, type: TabStopType): TabStop | undefined;
+  public addTabStop(position: number, type: TabStopType): TabStop | undefined;
 
   /** @inheritDoc */
-  public addTabStop (tabStop: TabStop): TabStop | undefined;
-  public addTabStop (arg1: number | TabStop, type = TabStopType.Left): TabStop | undefined {
+  public addTabStop(tabStop: TabStop): TabStop | undefined;
+  public addTabStop(
+    arg1: number | TabStop,
+    type = TabStopType.Left
+  ): TabStop | undefined {
     return this.paragraphProperties.addTabStop(arg1 as any, type);
   }
 
   /** @inheritdoc */
-  public getTabStops (): TabStop[] {
+  public getTabStops(): TabStop[] {
     return this.paragraphProperties.getTabStops();
   }
 
   /** @inheritdoc */
-  public clearTabStops (): ParagraphStyle {
+  public clearTabStops(): ParagraphStyle {
     this.paragraphProperties.clearTabStops();
 
     return this;
@@ -415,74 +466,76 @@ export class ParagraphStyle extends Style implements IParagraphProperties, IText
   // text properties
 
   /** @inheritDoc */
-  public setColor (color: Color | undefined): ParagraphStyle {
+  public setColor(color: Color | undefined): ParagraphStyle {
     this.textProperties.setColor(color);
 
     return this;
   }
 
   /** @inheritDoc */
-  public getColor (): Color | undefined {
+  public getColor(): Color | undefined {
     return this.textProperties.getColor();
   }
 
   /** @inheritDoc */
-  public setFontName (name: string): ParagraphStyle {
+  public setFontName(name: string): ParagraphStyle {
     this.textProperties.setFontName(name);
 
     return this;
   }
 
   /** @inheritDoc */
-  public getFontName (): string | undefined {
+  public getFontName(): string | undefined {
     return this.textProperties.getFontName();
   }
 
   /** @inheritDoc */
-  public setFontSize (size: number): ParagraphStyle {
+  public setFontSize(size: number): ParagraphStyle {
     this.textProperties.setFontSize(size);
 
     return this;
   }
 
   /** @inheritDoc */
-  public getFontSize (): number {
+  public getFontSize(): number {
     return this.textProperties.getFontSize();
   }
 
   /** @inheritDoc */
-  public setTextTransformation (transformation: TextTransformation): ParagraphStyle {
+  public setTextTransformation(
+    transformation: TextTransformation
+  ): ParagraphStyle {
     this.textProperties.setTextTransformation(transformation);
 
     return this;
   }
 
   /** @inheritDoc */
-  public setFontVariant (fontVariant: FontVariant): ParagraphStyle {
+  public setFontVariant(fontVariant: FontVariant): ParagraphStyle {
     this.textProperties.setFontVariant(fontVariant);
 
     return this;
   }
 
   /** @inheritDoc */
-  public getFontVariant (): FontVariant {
+  public getFontVariant(): FontVariant {
     return this.textProperties.getFontVariant();
   }
 
   /** @inheritDoc */
-  public getTextTransformation (): TextTransformation {
+  public getTextTransformation(): TextTransformation {
     return this.textProperties.getTextTransformation();
   }
 
   /** @inheritDoc */
-  public setTypeface (typeface: Typeface): ParagraphStyle {
+  public setTypeface(typeface: Typeface): ParagraphStyle {
     this.textProperties.setTypeface(typeface);
 
     return this;
   }
 
   /** @inheritDoc */
-  public getTypeface (): Typeface {
+  public getTypeface(): Typeface {
     return this.textProperties.getTypeface();
   }
 }

--- a/src/api/style/Style.ts
+++ b/src/api/style/Style.ts
@@ -33,9 +33,12 @@ export class Style {
    *
    * @since 0.9.0
    */
-  public constructor (displayName: string, family: StyleFamily) {
+  public constructor(displayName: string, family: StyleFamily) {
     this.displayName = displayName;
-    this.name = displayName.replace(/[^a-zA-Z0-9]/g, (match) => `_${match.charCodeAt(0).toString(16)}_`);
+    this.name = displayName.replace(
+      /[^a-zA-Z0-9]/g,
+      (match) => `_${match.charCodeAt(0).toString(16)}_`
+    );
     this.family = family;
   }
 
@@ -51,7 +54,7 @@ export class Style {
    * @returns {Style} The `Style` object
    * @since 0.9.0
    */
-  public setClass (clazz: string | undefined): Style {
+  public setClass(clazz: string | undefined): Style {
     if (clazz === undefined || typeof clazz === 'string') {
       this.clazz = clazz;
     }
@@ -71,7 +74,7 @@ export class Style {
    * @returns {string | undefined} The name of the style class of the style or `undefined` if the style class is not set
    * @since 0.9.0
    */
-  public getClass (): string | undefined {
+  public getClass(): string | undefined {
     return this.clazz;
   }
 
@@ -85,7 +88,7 @@ export class Style {
    * @returns {string} The pretty and user-friendly name of a style
    * @since 0.9.0
    */
-  public getDisplayName (): string {
+  public getDisplayName(): string {
     return this.displayName;
   }
 
@@ -99,7 +102,7 @@ export class Style {
    * @returns {string} The family of the style
    * @since 0.9.0
    */
-  public getFamily (): string {
+  public getFamily(): string {
     return this.family;
   }
 
@@ -116,7 +119,7 @@ export class Style {
    * @returns {string} A string that identifies the style in this document
    * @since 0.9.0
    */
-  public getName (): string {
+  public getName(): string {
     return this.name;
   }
 }

--- a/src/api/style/StyleFamily.ts
+++ b/src/api/style/StyleFamily.ts
@@ -9,5 +9,5 @@ export enum StyleFamily {
   TableCell = 'table-cell',
   TableColumn = 'table-column',
   TableRow = 'table-row',
-  Text = 'text'
+  Text = 'text',
 }

--- a/src/api/style/TabStop.ts
+++ b/src/api/style/TabStop.ts
@@ -36,7 +36,10 @@ export class TabStop {
    * @param {TabStopType} [type=TabStopType.Left] The type of the tab stop
    * @since 0.3.0
    */
-  public constructor (private position: number, private type = TabStopType.Left) {
+  public constructor(
+    private position: number,
+    private type = TabStopType.Left
+  ) {
     this.setPosition(position);
     this.leaderStyle = TabStopLeaderStyle.None;
   }
@@ -53,7 +56,7 @@ export class TabStop {
    * @returns {string | undefined} The delimiter character or `undefined` if the delimiter character is not set
    * @since 0.10.0
    */
-  public getChar (): string | undefined {
+  public getChar(): string | undefined {
     return this.char;
   }
 
@@ -72,7 +75,7 @@ export class TabStop {
    * @returns {TabStop} The `TabStop` object
    * @since 0.10.0
    */
-  public setChar (char: string | undefined): TabStop {
+  public setChar(char: string | undefined): TabStop {
     if (char === undefined || char.length === 1) {
       this.char = char;
     }
@@ -92,7 +95,7 @@ export class TabStop {
    * @returns {Color | undefined} The color of a leader line or `undefined` if the current text color will be used
    * @since 0.10.0
    */
-  public getLeaderColor (): Color | undefined {
+  public getLeaderColor(): Color | undefined {
     return this.leaderColor;
   }
 
@@ -108,7 +111,7 @@ export class TabStop {
    * @returns {TabStop} The `TabStop` object
    * @since 0.10.0
    */
-  public setLeaderColor (color: Color | undefined): TabStop {
+  public setLeaderColor(color: Color | undefined): TabStop {
     this.leaderColor = color;
 
     return this;
@@ -126,7 +129,7 @@ export class TabStop {
    * @returns {TabStopLeaderStyle} The style for a leader line
    * @since 0.10.0
    */
-  public getLeaderStyle (): TabStopLeaderStyle {
+  public getLeaderStyle(): TabStopLeaderStyle {
     return this.leaderStyle;
   }
 
@@ -141,7 +144,7 @@ export class TabStop {
    * @returns {TabStop} The `TabStop` object
    * @since 0.10.0
    */
-  public setLeaderStyle (leaderStyle: TabStopLeaderStyle): TabStop {
+  public setLeaderStyle(leaderStyle: TabStopLeaderStyle): TabStop {
     this.leaderStyle = leaderStyle;
 
     return this;
@@ -160,7 +163,7 @@ export class TabStop {
    * @returns {number} The position of the tab stop in millimeters
    * @since 0.3.0
    */
-  public getPosition (): number {
+  public getPosition(): number {
     return this.position;
   }
 
@@ -178,7 +181,7 @@ export class TabStop {
    * @returns {TabStop} The `TabStop` object
    * @since 0.3.0
    */
-  public setPosition (position: number): TabStop {
+  public setPosition(position: number): TabStop {
     this.position = Math.max(position, 0);
 
     return this;
@@ -196,7 +199,7 @@ export class TabStop {
    * @returns {TabStopType} The type of the tab stop
    * @since 0.3.0
    */
-  public getType (): TabStopType {
+  public getType(): TabStopType {
     return this.type;
   }
 
@@ -211,7 +214,7 @@ export class TabStop {
    * @returns {TabStop} The `TabStop` object
    * @since 0.3.0
    */
-  public setType (type: TabStopType): TabStop {
+  public setType(type: TabStopType): TabStop {
     this.type = type;
 
     return this;

--- a/src/api/style/TabStopLeaderStyle.ts
+++ b/src/api/style/TabStopLeaderStyle.ts
@@ -14,5 +14,5 @@ export enum TabStopLeaderStyle {
   /** tab stop has a solid leader line */
   Solid = 'solid',
   /** tab stop has a wavy leader line */
-  Wave = 'wave'
+  Wave = 'wave',
 }

--- a/src/api/style/TabStopType.ts
+++ b/src/api/style/TabStopType.ts
@@ -2,5 +2,5 @@ export enum TabStopType {
   Left = 'left', // default
   Center = 'center',
   Right = 'right',
-  Char = 'char'
+  Char = 'char',
 }

--- a/src/api/style/TextProperties.ts
+++ b/src/api/style/TextProperties.ts
@@ -26,7 +26,7 @@ export class TextProperties implements ITextProperties {
    *
    * @since 0.4.0
    */
-  public constructor () {
+  public constructor() {
     this.fontSize = 12;
     this.fontVariant = FontVariant.Normal;
     this.transformation = TextTransformation.None;
@@ -34,74 +34,74 @@ export class TextProperties implements ITextProperties {
   }
 
   /** @inheritDoc */
-  public setBackgroundColor (color: Color | undefined): void {
+  public setBackgroundColor(color: Color | undefined): void {
     this.backgroundColor = color;
   }
 
   /** @inheritDoc */
-  public getBackgroundColor (): Color | undefined {
+  public getBackgroundColor(): Color | undefined {
     return this.backgroundColor;
   }
 
   /** @inheritDoc */
-  public setColor (color: Color | undefined): void {
+  public setColor(color: Color | undefined): void {
     this.color = color;
   }
 
   /** @inheritDoc */
-  public getColor (): Color | undefined {
+  public getColor(): Color | undefined {
     return this.color;
   }
 
   /** @inheritDoc */
-  public setFontName (name: string): void {
+  public setFontName(name: string): void {
     this.fontName = name;
   }
 
   /** @inheritDoc */
-  public getFontName (): string | undefined {
+  public getFontName(): string | undefined {
     return this.fontName;
   }
 
   /** @inheritDoc */
-  public setFontSize (size: number): void {
+  public setFontSize(size: number): void {
     if (isPositiveLength(size)) {
       this.fontSize = size;
     }
   }
 
   /** @inheritDoc */
-  public getFontSize (): number {
+  public getFontSize(): number {
     return this.fontSize;
   }
 
   /** @inheritDoc */
-  public setFontVariant (fontVariant: FontVariant): void {
+  public setFontVariant(fontVariant: FontVariant): void {
     this.fontVariant = fontVariant;
   }
 
   /** @inheritDoc */
-  public getFontVariant (): FontVariant {
+  public getFontVariant(): FontVariant {
     return this.fontVariant;
   }
 
   /** @inheritDoc */
-  public setTextTransformation (transformation: TextTransformation): void {
+  public setTextTransformation(transformation: TextTransformation): void {
     this.transformation = transformation;
   }
 
   /** @inheritDoc */
-  public getTextTransformation (): TextTransformation {
+  public getTextTransformation(): TextTransformation {
     return this.transformation;
   }
 
   /** @inheritDoc */
-  public setTypeface (typeface: Typeface): void {
+  public setTypeface(typeface: Typeface): void {
     this.typeface = typeface;
   }
 
   /** @inheritDoc */
-  public getTypeface (): Typeface {
+  public getTypeface(): Typeface {
     return this.typeface;
   }
 }

--- a/src/api/style/TextTransformation.ts
+++ b/src/api/style/TextTransformation.ts
@@ -2,5 +2,5 @@ export enum TextTransformation {
   None = 'none',
   Capitalize = 'capitalize',
   Lowercase = 'lowercase',
-  Uppercase = 'uppercase'
+  Uppercase = 'uppercase',
 }

--- a/src/api/style/Typeface.ts
+++ b/src/api/style/Typeface.ts
@@ -4,5 +4,5 @@ export enum Typeface {
   Italic,
   Oblique,
   BoldItalic,
-  BoldOblique
+  BoldOblique,
 }

--- a/src/api/style/VerticalAlignment.ts
+++ b/src/api/style/VerticalAlignment.ts
@@ -3,5 +3,5 @@ export enum VerticalAlignment {
   Top = 'top',
   Middle = 'middle',
   Bottom = 'bottom',
-  Baseline = 'baseline'
+  Baseline = 'baseline',
 }

--- a/src/api/text/Heading.ts
+++ b/src/api/text/Heading.ts
@@ -32,7 +32,7 @@ export class Heading extends Paragraph {
    * @param {number} [level=1] The level of the heading, starting with `1`; defaults to `1` if omitted
    * @since 0.1.0
    */
-  public constructor (text?: string, private level = Heading.DEFAULT_LEVEL) {
+  public constructor(text?: string, private level = Heading.DEFAULT_LEVEL) {
     super(text);
 
     this.setLevel(level);
@@ -46,7 +46,7 @@ export class Heading extends Paragraph {
    * @returns {Heading} The `Heading` object
    * @since 0.1.0
    */
-  public setLevel (level: number): Heading {
+  public setLevel(level: number): Heading {
     this.level = level > Heading.DEFAULT_LEVEL ? level : Heading.DEFAULT_LEVEL;
 
     return this;
@@ -58,7 +58,7 @@ export class Heading extends Paragraph {
    * @returns {number} The level of the heading
    * @since 0.1.0
    */
-  public getLevel (): number {
+  public getLevel(): number {
     return this.level;
   }
 }

--- a/src/api/text/Hyperlink.ts
+++ b/src/api/text/Hyperlink.ts
@@ -21,7 +21,7 @@ export class Hyperlink extends OdfTextElement {
    * @param {string} uri The target URI of the hyperlink
    * @since 0.3.0
    */
-  public constructor (text: string, private uri: string) {
+  public constructor(text: string, private uri: string) {
     super(text);
   }
 
@@ -38,7 +38,7 @@ export class Hyperlink extends OdfTextElement {
    * @returns {Hyperlink} The `Hyperlink` object
    * @since 0.3.0
    */
-  public setURI (uri: string): Hyperlink {
+  public setURI(uri: string): Hyperlink {
     if (typeof uri === 'string' && uri.trim().length > 0) {
       this.uri = uri;
     }
@@ -58,7 +58,7 @@ export class Hyperlink extends OdfTextElement {
    * @returns {string} The target URI of this hyperlink
    * @since 0.3.0
    */
-  public getURI (): string {
+  public getURI(): string {
     return this.uri;
   }
 }

--- a/src/api/text/List.spec.ts
+++ b/src/api/text/List.spec.ts
@@ -53,28 +53,48 @@ describe(List.name, () => {
       const insertedItem = list.insertItem(2, itemToAdd);
 
       expect(insertedItem).toEqual(itemToAdd);
-      expect(list.getItems()).toEqual([testItem1, testItem2, itemToAdd, testItem3]);
+      expect(list.getItems()).toEqual([
+        testItem1,
+        testItem2,
+        itemToAdd,
+        testItem3,
+      ]);
     });
 
     it('add new items to the specified position and return the added item', () => {
       const insertedItem = list.insertItem(2, itemToAdd);
 
       expect(insertedItem).toBe(itemToAdd);
-      expect(list.getItems()).toEqual([testItem1, testItem2, itemToAdd, testItem3]);
+      expect(list.getItems()).toEqual([
+        testItem1,
+        testItem2,
+        itemToAdd,
+        testItem3,
+      ]);
     });
 
     it('insert item at the front of the list if position is negative', () => {
       const insertedItem = list.insertItem(-2, itemToAdd);
 
       expect(insertedItem).toBe(itemToAdd);
-      expect(list.getItems()).toEqual([itemToAdd, testItem1, testItem2, testItem3]);
+      expect(list.getItems()).toEqual([
+        itemToAdd,
+        testItem1,
+        testItem2,
+        testItem3,
+      ]);
     });
 
     it('insert item at the end of the list if position is larger than the size of the list', () => {
       const insertedItem = list.insertItem(10, itemToAdd);
 
       expect(insertedItem).toBe(itemToAdd);
-      expect(list.getItems()).toEqual([testItem1, testItem2, testItem3, itemToAdd]);
+      expect(list.getItems()).toEqual([
+        testItem1,
+        testItem2,
+        testItem3,
+        itemToAdd,
+      ]);
     });
   });
 

--- a/src/api/text/List.ts
+++ b/src/api/text/List.ts
@@ -22,7 +22,7 @@ export class List extends OdfElement {
    *
    * @since 0.2.0
    */
-  public constructor () {
+  public constructor() {
     super();
   }
 
@@ -38,7 +38,7 @@ export class List extends OdfElement {
    * @returns {ListItem} The added `ListItem` object
    * @since 0.2.0
    */
-  public addItem (item?: ListItem): ListItem {
+  public addItem(item?: ListItem): ListItem {
     const listItem = item || new ListItem();
     this.append(listItem);
 
@@ -62,7 +62,7 @@ export class List extends OdfElement {
    * @returns {ListItem} The inserted `ListItem` object
    * @since 0.2.0
    */
-  public insertItem (position: number, item: ListItem): ListItem {
+  public insertItem(position: number, item: ListItem): ListItem {
     this.insert(position, item);
     return item;
   }
@@ -83,7 +83,7 @@ export class List extends OdfElement {
    * or `undefined` if there is no list item at the specified position
    * @since 0.2.0
    */
-  public getItem (position: number): ListItem | undefined {
+  public getItem(position: number): ListItem | undefined {
     return this.get(position) as ListItem;
   }
 
@@ -100,7 +100,7 @@ export class List extends OdfElement {
    * @returns {ListItem[]} A copy of the list of `ListItem` objects
    * @since 0.2.0
    */
-  public getItems (): ListItem[] {
+  public getItems(): ListItem[] {
     return this.getAll() as ListItem[];
   }
 
@@ -120,7 +120,7 @@ export class List extends OdfElement {
    * or undefined if there is no list item at the specified position
    * @since 0.2.0
    */
-  public removeItemAt (position: number): ListItem | undefined {
+  public removeItemAt(position: number): ListItem | undefined {
     return this.removeAt(position) as ListItem;
   }
 
@@ -137,7 +137,7 @@ export class List extends OdfElement {
    * @returns {List} The `List` object
    * @since 0.2.0
    */
-  public clear (): List {
+  public clear(): List {
     let removedElement;
 
     do {
@@ -160,7 +160,7 @@ export class List extends OdfElement {
    * @returns {number} The number of items in this list
    * @since 0.2.0
    */
-  public size (): number {
+  public size(): number {
     return this.getAll().length;
   }
 }

--- a/src/api/text/ListItem.ts
+++ b/src/api/text/ListItem.ts
@@ -23,7 +23,7 @@ export class ListItem extends OdfElement {
    *
    * @since 0.2.0
    */
-  public constructor () {
+  public constructor() {
     super();
   }
 
@@ -36,7 +36,7 @@ export class ListItem extends OdfElement {
    * @returns {Heading} The newly added heading
    * @since 0.11.0
    */
-  public addHeading (text?: string, level = 1): Heading {
+  public addHeading(text?: string, level = 1): Heading {
     const heading = new Heading(text, level);
     this.append(heading);
 
@@ -53,7 +53,7 @@ export class ListItem extends OdfElement {
    * @returns {List} The newly added list
    * @since 0.11.0
    */
-  public addList (): List {
+  public addList(): List {
     const list = new List();
     this.append(list);
 
@@ -68,7 +68,7 @@ export class ListItem extends OdfElement {
    * @returns {Paragraph} The newly added paragraph
    * @since 0.11.0
    */
-  public addParagraph (text?: string): Paragraph {
+  public addParagraph(text?: string): Paragraph {
     const paragraph = new Paragraph(text);
     this.append(paragraph);
 

--- a/src/api/text/OdfTextElement.ts
+++ b/src/api/text/OdfTextElement.ts
@@ -13,7 +13,7 @@ export class OdfTextElement extends OdfElement {
    * @param {string} text The text content
    * @since 0.3.0
    */
-  public constructor (private text: string) {
+  public constructor(private text: string) {
     super();
   }
 
@@ -23,7 +23,7 @@ export class OdfTextElement extends OdfElement {
    * @param {string} text The new text content
    * @since 0.3.0
    */
-  public setText (text: string): void {
+  public setText(text: string): void {
     this.text = text;
   }
 
@@ -33,7 +33,7 @@ export class OdfTextElement extends OdfElement {
    * @returns {string} The text content
    * @since 0.3.0
    */
-  public getText (): string {
+  public getText(): string {
     return this.text;
   }
 }

--- a/src/api/text/Paragraph.spec.ts
+++ b/src/api/text/Paragraph.spec.ts
@@ -41,13 +41,18 @@ describe(Paragraph.name, () => {
       paragraph.addHyperlink(' link', 'http://example.org/');
       paragraph.addText(' even more text');
 
-      expect(paragraph.getText()).toEqual('some text some\nmore   text link even more text');
+      expect(paragraph.getText()).toEqual(
+        'some text some\nmore   text link even more text'
+      );
     });
   });
 
   describe('hyperlink', () => {
     it('return a hyperlink', () => {
-      const hyperlink = paragraph.addHyperlink('some linked text', 'http://example.org/');
+      const hyperlink = paragraph.addHyperlink(
+        'some linked text',
+        'http://example.org/'
+      );
 
       expect(hyperlink).toBeInstanceOf(Hyperlink);
       expect(hyperlink.getText()).toEqual('some linked text');

--- a/src/api/text/Paragraph.ts
+++ b/src/api/text/Paragraph.ts
@@ -28,7 +28,7 @@ export class Paragraph extends OdfElement {
    * @param {string} [text] The text content of the paragraph; defaults to an empty string if omitted
    * @since 0.1.0
    */
-  public constructor (text?: string) {
+  public constructor(text?: string) {
     super();
 
     this.addText(text || '');
@@ -45,10 +45,13 @@ export class Paragraph extends OdfElement {
    * @returns {Paragraph} The `Paragraph` object
    * @since 0.1.0
    */
-  public addText (text: string): Paragraph {
+  public addText(text: string): Paragraph {
     const elements = this.getAll();
 
-    if (elements.length > 0 && elements[elements.length - 1].constructor.name === OdfTextElement.name) {
+    if (
+      elements.length > 0 &&
+      elements[elements.length - 1].constructor.name === OdfTextElement.name
+    ) {
       const lastElement = elements[elements.length - 1] as OdfTextElement;
       lastElement.setText(lastElement.getText() + text);
       return this;
@@ -72,7 +75,7 @@ export class Paragraph extends OdfElement {
    * @returns {string} The text content of the paragraph
    * @since 0.1.0
    */
-  public getText (): string {
+  public getText(): string {
     return this.getAll()
       .map((value: OdfElement) => {
         return value instanceof OdfTextElement ? value.getText() : '';
@@ -92,7 +95,7 @@ export class Paragraph extends OdfElement {
    * @returns {Paragraph} The `Paragraph` object
    * @since 0.1.0
    */
-  public setText (text: string): Paragraph {
+  public setText(text: string): Paragraph {
     this.removeText();
     this.addText(text || '');
 
@@ -111,7 +114,7 @@ export class Paragraph extends OdfElement {
    * @returns {Hyperlink} The added `Hyperlink` object
    * @since 0.3.0
    */
-  public addHyperlink (text: string, uri: string): Hyperlink {
+  public addHyperlink(text: string, uri: string): Hyperlink {
     const hyperlink = new Hyperlink(text, uri);
     this.append(hyperlink);
 
@@ -130,7 +133,7 @@ export class Paragraph extends OdfElement {
    * @returns {Image} The added `Image` object
    * @since 0.3.0
    */
-  public addImage (path: string): Image {
+  public addImage(path: string): Image {
     const image = new Image(path);
     this.append(image);
 
@@ -151,7 +154,7 @@ export class Paragraph extends OdfElement {
    * @returns {Paragraph} The `Paragraph` object
    * @since 0.3.0
    */
-  public setStyle (style: ParagraphStyle | undefined): Paragraph {
+  public setStyle(style: ParagraphStyle | undefined): Paragraph {
     this.style = style;
 
     return this;
@@ -169,7 +172,7 @@ export class Paragraph extends OdfElement {
    * @returns {ParagraphStyle | undefined} The style of the paragraph or `undefined` if no style was set
    * @since 0.3.0
    */
-  public getStyle (): ParagraphStyle | undefined {
+  public getStyle(): ParagraphStyle | undefined {
     return this.style;
   }
 
@@ -187,7 +190,7 @@ export class Paragraph extends OdfElement {
    * @returns {Paragraph} The `Paragraph` object
    * @since 0.9.0
    */
-  public setStyleName (styleName: string | undefined): Paragraph {
+  public setStyleName(styleName: string | undefined): Paragraph {
     this.styleName = styleName;
 
     return this;
@@ -205,7 +208,7 @@ export class Paragraph extends OdfElement {
    * @returns {string | undefined} The name of the common style or `undefined` if no common style was set
    * @since 0.3.0
    */
-  public getStyleName (): string | undefined {
+  public getStyleName(): string | undefined {
     return this.styleName;
   }
 
@@ -219,7 +222,7 @@ export class Paragraph extends OdfElement {
    * @returns {Paragraph} The `Paragraph` object
    * @private
    */
-  private removeText (): Paragraph {
+  private removeText(): Paragraph {
     const elements = this.getAll();
 
     for (let index = elements.length - 1; index >= 0; index--) {

--- a/src/api/util/isNonNegativeNumber.ts
+++ b/src/api/util/isNonNegativeNumber.ts
@@ -7,6 +7,6 @@
  * @returns {boolean} `true` if the given value is a non-negative number, `false` otherwise
  * @private
  */
-export function isNonNegativeNumber (value: any): boolean {
+export function isNonNegativeNumber(value: any): boolean {
   return typeof value === 'number' && value > 0;
 }

--- a/src/api/util/isPercent.ts
+++ b/src/api/util/isPercent.ts
@@ -7,6 +7,8 @@
  * @returns {boolean} `true` if the given value is a percentage, `false` otherwise
  * @private
  */
-export function isPercent (value: any): boolean {
-  return typeof value === 'string' && /^-?([0-9]+(\.[0-9]*)?|\.[0-9]+)%$/.test(value);
+export function isPercent(value: any): boolean {
+  return (
+    typeof value === 'string' && /^-?([0-9]+(\.[0-9]*)?|\.[0-9]+)%$/.test(value)
+  );
 }

--- a/src/api/util/isPositiveLength.ts
+++ b/src/api/util/isPositiveLength.ts
@@ -7,6 +7,6 @@
  * @returns {boolean} `true` if the given value is a positive number, `false` otherwise
  * @private
  */
-export function isPositiveLength (value: any): boolean {
+export function isPositiveLength(value: any): boolean {
   return typeof value === 'number' && value >= 0;
 }

--- a/src/xml/AutomaticStyleVisitor.ts
+++ b/src/xml/AutomaticStyleVisitor.ts
@@ -3,10 +3,9 @@ import { AutomaticStyles } from '../api/office';
 import { Heading, Paragraph } from '../api/text';
 
 export class AutomaticStyleVisitor {
-  public constructor (private automaticStyles: AutomaticStyles) {
-  }
+  public constructor(private automaticStyles: AutomaticStyles) {}
 
-  public visit (odfElement: OdfElement): void {
+  public visit(odfElement: OdfElement): void {
     if (odfElement instanceof Heading) {
       this.visitHeading(odfElement, this.automaticStyles);
     } else if (odfElement instanceof Paragraph) {
@@ -18,7 +17,10 @@ export class AutomaticStyleVisitor {
     });
   }
 
-  private visitHeading (heading: Heading, automaticStyles: AutomaticStyles): void {
+  private visitHeading(
+    heading: Heading,
+    automaticStyles: AutomaticStyles
+  ): void {
     const style = heading.getStyle();
 
     if (style === undefined) {
@@ -28,7 +30,10 @@ export class AutomaticStyleVisitor {
     automaticStyles.add(style);
   }
 
-  private visitParagraph (paragraph: Paragraph, automaticStyles: AutomaticStyles): void {
+  private visitParagraph(
+    paragraph: Paragraph,
+    automaticStyles: AutomaticStyles
+  ): void {
     const style = paragraph.getStyle();
 
     if (style === undefined) {

--- a/src/xml/DomVisitor.spec.ts
+++ b/src/xml/DomVisitor.spec.ts
@@ -8,13 +8,13 @@ import { AutomaticStyles, CommonStyles } from '../api/office';
 import { ParagraphStyle } from '../api/style';
 
 class AutomaticStylesMock extends AutomaticStyles {
-  public getName (): string {
+  public getName(): string {
     return 'P23';
   }
 }
 
 class CommonStylesMock extends CommonStyles {
-  public getName (): string {
+  public getName(): string {
     return 'encodedTestStyleName';
   }
 }
@@ -30,7 +30,11 @@ describe(DomVisitor.name, () => {
     let automaticStyles: AutomaticStylesMock;
 
     beforeEach(() => {
-      testDocument = new DOMImplementation().createDocument('someNameSpace', OdfElementName.OfficeDocument, null);
+      testDocument = new DOMImplementation().createDocument(
+        'someNameSpace',
+        OdfElementName.OfficeDocument,
+        null
+      );
       testRoot = testDocument.firstChild as Element;
 
       commonStyles = new CommonStylesMock();
@@ -49,8 +53,12 @@ describe(DomVisitor.name, () => {
       it('add a heading with level 2 and the text', () => {
         domVisitor.visit(heading, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:h text:outline-level="2">some text<\/text:h>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:h text:outline-level="2">some text<\/text:h>/
+        );
       });
 
       it('add a heading with a common style', () => {
@@ -58,8 +66,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(heading, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:h text:outline-level="2" text:style-name="encodedTestStyleName">some text<\/text:h>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:h text:outline-level="2" text:style-name="encodedTestStyleName">some text<\/text:h>/
+        );
       });
 
       it('add a heading with an automatic style', () => {
@@ -67,8 +79,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(heading, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:h text:outline-level="2" text:style-name="P23">some text<\/text:h>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:h text:outline-level="2" text:style-name="P23">some text<\/text:h>/
+        );
       });
     });
 
@@ -82,8 +98,12 @@ describe(DomVisitor.name, () => {
       it('add a linked text', () => {
         domVisitor.visit(hyperlink, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:a xlink:type="simple" xlink:href="http:\/\/example.org\/">some text<\/text:a>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:a xlink:type="simple" xlink:href="http:\/\/example.org\/">some text<\/text:a>/
+        );
       });
     });
 
@@ -91,15 +111,20 @@ describe(DomVisitor.name, () => {
       let image: Image;
 
       beforeEach(() => {
-        image = new Image(join(__dirname, '..', '..', 'test', 'data', 'ODF.png'))
-          .setAnchorType(AnchorType.AsChar);
+        image = new Image(
+          join(__dirname, '..', '..', 'test', 'data', 'ODF.png')
+        ).setAnchorType(AnchorType.AsChar);
       });
 
       it('add a draw frame with image and base64 encoded image', () => {
         domVisitor.visit(image, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<draw:frame text:anchor-type="as-char"><draw:image><office:binary-data>.*<\/office:binary-data><\/draw:image><\/draw:frame>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<draw:frame text:anchor-type="as-char"><draw:image><office:binary-data>.*<\/office:binary-data><\/draw:image><\/draw:frame>/
+        );
       });
 
       it('add a draw frame with image and set height', () => {
@@ -107,8 +132,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(image, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<draw:frame text:anchor-type="as-char" svg:height="23mm"><draw:image><office:binary-data>.*<\/office:binary-data><\/draw:image><\/draw:frame>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<draw:frame text:anchor-type="as-char" svg:height="23mm"><draw:image><office:binary-data>.*<\/office:binary-data><\/draw:image><\/draw:frame>/
+        );
       });
 
       it('add a draw frame with image and set width', () => {
@@ -116,8 +145,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(image, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<draw:frame text:anchor-type="as-char" svg:width="42mm"><draw:image><office:binary-data>.*<\/office:binary-data><\/draw:image><\/draw:frame>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<draw:frame text:anchor-type="as-char" svg:width="42mm"><draw:image><office:binary-data>.*<\/office:binary-data><\/draw:image><\/draw:frame>/
+        );
       });
     });
 
@@ -131,7 +164,9 @@ describe(DomVisitor.name, () => {
       it('NOT insert an empty list', () => {
         domVisitor.visit(list, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
         expect(documentAsString).not.toMatch(/<text:list/);
       });
 
@@ -140,8 +175,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(list, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:list><text:list-item><text:h text:outline-level="2">some text<\/text:h><\/text:list-item><\/text:list>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:list><text:list-item><text:h text:outline-level="2">some text<\/text:h><\/text:list-item><\/text:list>/
+        );
       });
 
       it('insert a list with a list item and a nested paragraph', () => {
@@ -149,8 +188,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(list, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:list><text:list-item><text:p>some text<\/text:p><\/text:list-item><\/text:list>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:list><text:list-item><text:p>some text<\/text:p><\/text:list-item><\/text:list>/
+        );
       });
     });
 
@@ -166,8 +209,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(paragraph, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:p>some text<text:line-break\/>some more text<\/text:p>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:p>some text<text:line-break\/>some more text<\/text:p>/
+        );
       });
 
       it('replace tab with tabulation', () => {
@@ -175,8 +222,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(paragraph, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:p>some<text:tab\/>tabbed<text:tab\/><text:tab\/>text<\/text:p>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:p>some<text:tab\/>tabbed<text:tab\/><text:tab\/>text<\/text:p>/
+        );
       });
 
       it('replace sequence of spaces with space node', () => {
@@ -184,8 +235,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(paragraph, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:p> some <text:s\/>spacey <text:s c="2"\/>text <text:s c="3"\/><\/text:p>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:p> some <text:s\/>spacey <text:s c="2"\/>text <text:s c="3"\/><\/text:p>/
+        );
       });
 
       it('ignore carriage return character', () => {
@@ -193,8 +248,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(paragraph, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:p>some text<text:line-break\/>some more text<\/text:p>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:p>some text<text:line-break\/>some more text<\/text:p>/
+        );
       });
     });
 
@@ -210,14 +269,18 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(paragraph, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
         expect(documentAsString).toMatch(/<text:p\/>/);
       });
 
       it('add a paragraph with specified text', () => {
         domVisitor.visit(paragraph, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
         expect(documentAsString).toMatch(/<text:p>some text<\/text:p>/);
       });
 
@@ -226,8 +289,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(paragraph, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:p text:style-name="encodedTestStyleName">some text<\/text:p>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:p text:style-name="encodedTestStyleName">some text<\/text:p>/
+        );
       });
 
       it('add a paragraph with an automatic style', () => {
@@ -235,8 +302,12 @@ describe(DomVisitor.name, () => {
 
         domVisitor.visit(paragraph, testDocument, testRoot);
 
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
-        expect(documentAsString).toMatch(/<text:p text:style-name="P23">some text<\/text:p>/);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
+        expect(documentAsString).toMatch(
+          /<text:p text:style-name="P23">some text<\/text:p>/
+        );
       });
     });
   });

--- a/src/xml/DomVisitor.ts
+++ b/src/xml/DomVisitor.ts
@@ -2,7 +2,14 @@ import { readFileSync } from 'fs';
 import { Image } from '../api/draw';
 import { OdfElement } from '../api/OdfElement';
 import { AutomaticStyles, CommonStyles, TextBody } from '../api/office';
-import { Heading, Hyperlink, List, ListItem, OdfTextElement, Paragraph } from '../api/text';
+import {
+  Heading,
+  Hyperlink,
+  List,
+  ListItem,
+  OdfTextElement,
+  Paragraph,
+} from '../api/text';
 import { DrawElementName } from './DrawElementName';
 import { OdfAttributeName } from './OdfAttributeName';
 import { OdfElementName } from './OdfElementName';
@@ -13,10 +20,16 @@ const IMAGE_ENCODING = 'base64';
 const HYPERLINK_LINK_TYPE = 'simple';
 
 export class DomVisitor {
-  public constructor (private commonStyles: CommonStyles, private automaticStyles: AutomaticStyles) {
-  }
+  public constructor(
+    private commonStyles: CommonStyles,
+    private automaticStyles: AutomaticStyles
+  ) {}
 
-  public visit (odfElement: OdfElement, document: Document, parent: Element): void {
+  public visit(
+    odfElement: OdfElement,
+    document: Document,
+    parent: Element
+  ): void {
     let currentElement: Element;
     if (odfElement instanceof Heading) {
       currentElement = this.visitHeading(odfElement, document, parent);
@@ -41,9 +54,16 @@ export class DomVisitor {
     });
   }
 
-  private visitHeading (heading: Heading, document: Document, parent: Element): Element {
+  private visitHeading(
+    heading: Heading,
+    document: Document,
+    parent: Element
+  ): Element {
     const headingElement = document.createElement(TextElementName.TextHeading);
-    headingElement.setAttribute(OdfAttributeName.TextOutlineLevel, heading.getLevel().toString(10));
+    headingElement.setAttribute(
+      OdfAttributeName.TextOutlineLevel,
+      heading.getLevel().toString(10)
+    );
     parent.appendChild(headingElement);
 
     this.setStyleName(heading, headingElement);
@@ -51,10 +71,22 @@ export class DomVisitor {
     return headingElement;
   }
 
-  private visitHyperlink (hyperlink: Hyperlink, document: Document, parent: Element): Element {
-    const hyperlinkElement = document.createElement(TextElementName.TextHyperlink);
-    hyperlinkElement.setAttribute(OdfAttributeName.XlinkType, HYPERLINK_LINK_TYPE);
-    hyperlinkElement.setAttribute(OdfAttributeName.XlinkHref, hyperlink.getURI());
+  private visitHyperlink(
+    hyperlink: Hyperlink,
+    document: Document,
+    parent: Element
+  ): Element {
+    const hyperlinkElement = document.createElement(
+      TextElementName.TextHyperlink
+    );
+    hyperlinkElement.setAttribute(
+      OdfAttributeName.XlinkType,
+      HYPERLINK_LINK_TYPE
+    );
+    hyperlinkElement.setAttribute(
+      OdfAttributeName.XlinkHref,
+      hyperlink.getURI()
+    );
     parent.appendChild(hyperlinkElement);
 
     this.visitOdfText(hyperlink, document, hyperlinkElement);
@@ -62,9 +94,16 @@ export class DomVisitor {
     return hyperlinkElement;
   }
 
-  private visitImage (image: Image, document: Document, parent: Element): Element {
+  private visitImage(
+    image: Image,
+    document: Document,
+    parent: Element
+  ): Element {
     const frameElement = document.createElement(DrawElementName.DrawFrame);
-    frameElement.setAttribute(OdfAttributeName.TextAnchorType, image.getAnchorType());
+    frameElement.setAttribute(
+      OdfAttributeName.TextAnchorType,
+      image.getAnchorType()
+    );
 
     const width = image.getWidth();
     if (width !== undefined) {
@@ -83,7 +122,7 @@ export class DomVisitor {
     return frameElement;
   }
 
-  private visitList (list: List, document: Document, parent: Element): Element {
+  private visitList(list: List, document: Document, parent: Element): Element {
     if (list.size() === 0) {
       return parent;
     }
@@ -94,20 +133,32 @@ export class DomVisitor {
     return listElement;
   }
 
-  private visitListItem (document: Document, parent: Element): Element {
-    const listItemElement = document.createElement(TextElementName.TextListItem);
+  private visitListItem(document: Document, parent: Element): Element {
+    const listItemElement = document.createElement(
+      TextElementName.TextListItem
+    );
     parent.appendChild(listItemElement);
 
     return listItemElement;
   }
 
-  private visitOdfText (odfText: OdfTextElement, document: Document, parent: Element): Element {
+  private visitOdfText(
+    odfText: OdfTextElement,
+    document: Document,
+    parent: Element
+  ): Element {
     new OdfTextElementWriter().write(odfText, document, parent);
     return parent;
   }
 
-  private visitParagraph (paragraph: Paragraph, document: Document, parent: Element): Element {
-    const paragraphElement = document.createElement(TextElementName.TextParagraph);
+  private visitParagraph(
+    paragraph: Paragraph,
+    document: Document,
+    parent: Element
+  ): Element {
+    const paragraphElement = document.createElement(
+      TextElementName.TextParagraph
+    );
     parent.appendChild(paragraphElement);
 
     this.setStyleName(paragraph, paragraphElement);
@@ -115,7 +166,7 @@ export class DomVisitor {
     return paragraphElement;
   }
 
-  private visitTextBody (document: Document, parent: Element): Element {
+  private visitTextBody(document: Document, parent: Element): Element {
     const bodyElement = document.createElement(OdfElementName.OfficeBody);
     parent.appendChild(bodyElement);
 
@@ -125,7 +176,10 @@ export class DomVisitor {
     return textElement;
   }
 
-  private setStyleName (odfElement: Heading | Paragraph, domElement: Element): void {
+  private setStyleName(
+    odfElement: Heading | Paragraph,
+    domElement: Element
+  ): void {
     let styleName = this.getAutomaticStyleName(odfElement);
 
     if (styleName === undefined) {
@@ -137,16 +191,24 @@ export class DomVisitor {
     }
   }
 
-  private getAutomaticStyleName (odfElement: Heading | Paragraph): string | undefined {
+  private getAutomaticStyleName(
+    odfElement: Heading | Paragraph
+  ): string | undefined {
     const style = odfElement.getStyle();
 
-    return style !== undefined ? this.automaticStyles.getName(style) : undefined;
+    return style !== undefined
+      ? this.automaticStyles.getName(style)
+      : undefined;
   }
 
-  private getCommonStyleName (odfElement: Heading | Paragraph): string | undefined {
+  private getCommonStyleName(
+    odfElement: Heading | Paragraph
+  ): string | undefined {
     const styleName = odfElement.getStyleName();
 
-    return styleName !== undefined ? this.commonStyles.getName(styleName) : undefined;
+    return styleName !== undefined
+      ? this.commonStyles.getName(styleName)
+      : undefined;
   }
 
   /**
@@ -157,7 +219,11 @@ export class DomVisitor {
    * @param {Image} image The image
    * @private
    */
-  private embedImage (document: Document, frameElement: Element, image: Image): void {
+  private embedImage(
+    document: Document,
+    frameElement: Element,
+    image: Image
+  ): void {
     const imageElement = document.createElement(DrawElementName.DrawImage);
     frameElement.appendChild(imageElement);
 

--- a/src/xml/DrawElementName.ts
+++ b/src/xml/DrawElementName.ts
@@ -1,4 +1,4 @@
 export enum DrawElementName {
   DrawFrame = 'draw:frame',
-  DrawImage = 'draw:image'
+  DrawImage = 'draw:image',
 }

--- a/src/xml/OdfAttributeName.ts
+++ b/src/xml/OdfAttributeName.ts
@@ -52,5 +52,5 @@ export enum OdfAttributeName {
   TextStyleName = 'text:style-name',
 
   XlinkHref = 'xlink:href',
-  XlinkType = 'xlink:type'
+  XlinkType = 'xlink:type',
 }

--- a/src/xml/OdfElementName.ts
+++ b/src/xml/OdfElementName.ts
@@ -13,5 +13,5 @@ export enum OdfElementName {
   StyleStyle = 'style:style',
   StyleTabStop = 'style:tab-stop',
   StyleTabStops = 'style:tab-stops',
-  StyleTextProperties = 'style:text-properties'
+  StyleTextProperties = 'style:text-properties',
 }

--- a/src/xml/OdfTextElementWriter.ts
+++ b/src/xml/OdfTextElementWriter.ts
@@ -8,7 +8,11 @@ export class OdfTextElementWriter {
    * @inheritdoc
    * @since 0.7.0
    */
-  public write (odfText: OdfTextElement, document: Document, parent: Element): void {
+  public write(
+    odfText: OdfTextElement,
+    document: Document,
+    parent: Element
+  ): void {
     const text = odfText.getText();
     if (text === undefined || text === '') {
       return;
@@ -58,7 +62,11 @@ export class OdfTextElementWriter {
    * @param {string} text The text value of the text node
    * @since 0.3.0
    */
-  private appendTextNode (document: Document, parent: Element, text: string): void {
+  private appendTextNode(
+    document: Document,
+    parent: Element,
+    text: string
+  ): void {
     if (text.length === 0) {
       return;
     }
@@ -76,7 +84,11 @@ export class OdfTextElementWriter {
    * @param {number} count The number of space characters the node should represent
    * @since 0.3.0
    */
-  private appendSpaceNode (document: Document, parent: Element, count: number): void {
+  private appendSpaceNode(
+    document: Document,
+    parent: Element,
+    count: number
+  ): void {
     const space = document.createElement(TextElementName.TextSpace);
     parent.appendChild(space);
 
@@ -92,7 +104,7 @@ export class OdfTextElementWriter {
    * @param {Element} parent The parent node
    * @since 0.3.0
    */
-  private appendTabNode (document: Document, parent: Element): void {
+  private appendTabNode(document: Document, parent: Element): void {
     const tabulation = document.createElement(TextElementName.TextTabulation);
     parent.appendChild(tabulation);
   }
@@ -104,7 +116,7 @@ export class OdfTextElementWriter {
    * @param {Element} parent The parent node
    * @since 0.3.0
    */
-  private appendLineBreakNode (document: Document, parent: Element): void {
+  private appendLineBreakNode(document: Document, parent: Element): void {
     const lineBreak = document.createElement(TextElementName.TextLineBreak);
     parent.appendChild(lineBreak);
   }
@@ -117,7 +129,7 @@ export class OdfTextElementWriter {
    * @returns {number} The number of space characters before the next non-space character
    * @since 0.3.0
    */
-  private findNextNonSpaceCharacter (text: string, offset: number): number {
+  private findNextNonSpaceCharacter(text: string, offset: number): number {
     for (let index = offset; index < text.length; index++) {
       if (text.charAt(index) !== SPACE) {
         return index - offset;

--- a/src/xml/TextDocumentWriter.spec.ts
+++ b/src/xml/TextDocumentWriter.spec.ts
@@ -27,35 +27,51 @@ describe(TextDocumentWriter.name, () => {
     });
 
     it('add dc namespace', () => {
-      expect(documentAsString).toMatch(/xmlns:dc="http:\/\/purl.org\/dc\/elements\/1.1\/"/);
+      expect(documentAsString).toMatch(
+        /xmlns:dc="http:\/\/purl.org\/dc\/elements\/1.1\/"/
+      );
     });
 
     it('add draw namespace', () => {
-      expect(documentAsString).toMatch(/xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"/);
+      expect(documentAsString).toMatch(
+        /xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"/
+      );
     });
 
     it('add fo namespace', () => {
-      expect(documentAsString).toMatch(/xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"/);
+      expect(documentAsString).toMatch(
+        /xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"/
+      );
     });
 
     it('add meta namespace', () => {
-      expect(documentAsString).toMatch(/xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"/);
+      expect(documentAsString).toMatch(
+        /xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"/
+      );
     });
 
     it('add style namespace', () => {
-      expect(documentAsString).toMatch(/xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"/);
+      expect(documentAsString).toMatch(
+        /xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"/
+      );
     });
 
     it('add svg namespace', () => {
-      expect(documentAsString).toMatch(/xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"/);
+      expect(documentAsString).toMatch(
+        /xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"/
+      );
     });
 
     it('add text namespace', () => {
-      expect(documentAsString).toMatch(/xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/);
+      expect(documentAsString).toMatch(
+        /xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"/
+      );
     });
 
     it('add xlink namespace', () => {
-      expect(documentAsString).toMatch(/xmlns:xlink="http:\/\/www.w3.org\/1999\/xlink"/);
+      expect(documentAsString).toMatch(
+        /xmlns:xlink="http:\/\/www.w3.org\/1999\/xlink"/
+      );
     });
   });
 });

--- a/src/xml/TextDocumentWriter.ts
+++ b/src/xml/TextDocumentWriter.ts
@@ -20,7 +20,7 @@ export class TextDocumentWriter {
   private metaWriter: MetaWriter;
   private stylesWriter: StylesWriter;
 
-  public constructor () {
+  public constructor() {
     this.fontFaceDeclarationsWriter = new FontFaceDeclarationsWriter();
     this.metaWriter = new MetaWriter();
     this.stylesWriter = new StylesWriter();
@@ -33,11 +33,12 @@ export class TextDocumentWriter {
    * @returns {Document} The XML document
    * @since 0.7.0
    */
-  public write (textDocument: TextDocument): Document {
+  public write(textDocument: TextDocument): Document {
     const document = new DOMImplementation().createDocument(
       'urn:oasis:names:tc:opendocument:xmlns:office:1.0',
       OdfElementName.OfficeDocument,
-      null);
+      null
+    );
     const root = document.firstChild as Element;
 
     this.setXmlNamespaces(root);
@@ -59,14 +60,32 @@ export class TextDocumentWriter {
    * @param {Element} root The root element of the document which will be used as parent
    * @private
    */
-  private setXmlNamespaces (root: Element): void {
+  private setXmlNamespaces(root: Element): void {
     root.setAttribute('xmlns:dc', 'http://purl.org/dc/elements/1.1/');
-    root.setAttribute('xmlns:draw', 'urn:oasis:names:tc:opendocument:xmlns:drawing:1.0');
-    root.setAttribute('xmlns:fo', 'urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0');
-    root.setAttribute('xmlns:meta', 'urn:oasis:names:tc:opendocument:xmlns:meta:1.0');
-    root.setAttribute('xmlns:style', 'urn:oasis:names:tc:opendocument:xmlns:style:1.0');
-    root.setAttribute('xmlns:svg', 'urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0');
-    root.setAttribute('xmlns:text', 'urn:oasis:names:tc:opendocument:xmlns:text:1.0');
+    root.setAttribute(
+      'xmlns:draw',
+      'urn:oasis:names:tc:opendocument:xmlns:drawing:1.0'
+    );
+    root.setAttribute(
+      'xmlns:fo',
+      'urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0'
+    );
+    root.setAttribute(
+      'xmlns:meta',
+      'urn:oasis:names:tc:opendocument:xmlns:meta:1.0'
+    );
+    root.setAttribute(
+      'xmlns:style',
+      'urn:oasis:names:tc:opendocument:xmlns:style:1.0'
+    );
+    root.setAttribute(
+      'xmlns:svg',
+      'urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0'
+    );
+    root.setAttribute(
+      'xmlns:text',
+      'urn:oasis:names:tc:opendocument:xmlns:text:1.0'
+    );
     root.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
   }
 
@@ -76,8 +95,11 @@ export class TextDocumentWriter {
    * @param {Element} root The root element of the document which will be used as parent
    * @private
    */
-  private setOfficeAttributes (root: Element): void {
-    root.setAttribute(OdfAttributeName.OfficeMimetype, 'application/vnd.oasis.opendocument.text');
+  private setOfficeAttributes(root: Element): void {
+    root.setAttribute(
+      OdfAttributeName.OfficeMimetype,
+      'application/vnd.oasis.opendocument.text'
+    );
     root.setAttribute(OdfAttributeName.OfficeVersion, OFFICE_VERSION);
   }
 
@@ -89,7 +111,11 @@ export class TextDocumentWriter {
    * @param {Element} root The root element of the document which will be used as parent
    * @private
    */
-  private writeMeta (textDocument: TextDocument, document: Document, root: Element): void {
+  private writeMeta(
+    textDocument: TextDocument,
+    document: Document,
+    root: Element
+  ): void {
     this.metaWriter.write(document, root, textDocument.getMeta());
   }
 
@@ -101,8 +127,16 @@ export class TextDocumentWriter {
    * @param {Element} root The root element of the document which will be used as parent
    * @private
    */
-  private writeFontFaceDeclarations (textDocument: TextDocument, document: Document, root: Element): void {
-    this.fontFaceDeclarationsWriter.write(textDocument.getFontFaceDeclarations(), document, root);
+  private writeFontFaceDeclarations(
+    textDocument: TextDocument,
+    document: Document,
+    root: Element
+  ): void {
+    this.fontFaceDeclarationsWriter.write(
+      textDocument.getFontFaceDeclarations(),
+      document,
+      root
+    );
   }
 
   /**
@@ -114,11 +148,12 @@ export class TextDocumentWriter {
    * @param {Element} root The root element of the document which will be used as parent
    * @private
    */
-  private writeStyles (
+  private writeStyles(
     textDocument: TextDocument,
     automaticStyles: AutomaticStyles,
     document: Document,
-    root: Element): void {
+    root: Element
+  ): void {
     new AutomaticStyleVisitor(automaticStyles).visit(textDocument.getBody());
 
     this.stylesWriter.write(textDocument.getCommonStyles(), document, root);
@@ -134,12 +169,16 @@ export class TextDocumentWriter {
    * @param {Element} root The root element of the document which will be used as parent
    * @private
    */
-  private writeBody (
+  private writeBody(
     textDocument: TextDocument,
     automaticStyles: AutomaticStyles,
     document: Document,
-    root: Element): void {
-    new DomVisitor(textDocument.getCommonStyles(), automaticStyles)
-      .visit(textDocument.getBody(), document, root);
+    root: Element
+  ): void {
+    new DomVisitor(textDocument.getCommonStyles(), automaticStyles).visit(
+      textDocument.getBody(),
+      document,
+      root
+    );
   }
 }

--- a/src/xml/TextElementName.ts
+++ b/src/xml/TextElementName.ts
@@ -6,5 +6,5 @@ export enum TextElementName {
   TextListItem = 'text:list-item',
   TextParagraph = 'text:p',
   TextSpace = 'text:s',
-  TextTabulation = 'text:tab'
+  TextTabulation = 'text:tab',
 }

--- a/src/xml/meta/MetaElementName.ts
+++ b/src/xml/meta/MetaElementName.ts
@@ -12,5 +12,5 @@ export enum MetaElementName {
   MetaInitialCreator = 'meta:initial-creator',
   MetaKeyword = 'meta:keyword',
   MetaPrintDate = 'meta:print-date',
-  MetaPrintedBy = 'meta:printed-by'
+  MetaPrintedBy = 'meta:printed-by',
 }

--- a/src/xml/meta/MetaWriter.spec.ts
+++ b/src/xml/meta/MetaWriter.spec.ts
@@ -12,7 +12,11 @@ describe(MetaWriter.name, () => {
     let meta: Meta;
 
     beforeEach(() => {
-      testDocument = new DOMImplementation().createDocument('someNameSpace', OdfElementName.OfficeDocument, null);
+      testDocument = new DOMImplementation().createDocument(
+        'someNameSpace',
+        OdfElementName.OfficeDocument,
+        null
+      );
       testRoot = testDocument.firstChild as Element;
       meta = new Meta();
 
@@ -22,18 +26,25 @@ describe(MetaWriter.name, () => {
     it('append creator, date, creation-date, editing-cycles and generator as default properties', () => {
       metaWriter.write(testDocument, testRoot, meta);
 
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
-      const regex = new RegExp('<office:meta>' +
-        '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>' +
-        '<meta:initial-creator>' + userInfo().username + '</meta:initial-creator>' +
-        '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>' +
-        '<meta:editing-cycles>1</meta:editing-cycles>' +
-        '</office:meta>');
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
+      const regex = new RegExp(
+        '<office:meta>' +
+          '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>' +
+          '<meta:initial-creator>' +
+          userInfo().username +
+          '</meta:initial-creator>' +
+          '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>' +
+          '<meta:editing-cycles>1</meta:editing-cycles>' +
+          '</office:meta>'
+      );
       expect(documentAsString).toMatch(regex);
     });
 
     it('ignore description, language, subject, title if they are empty', () => {
-      meta.setCreator('')
+      meta
+        .setCreator('')
         .setDate(undefined)
         .setDescription('')
         .setInitialCreator('')
@@ -43,17 +54,22 @@ describe(MetaWriter.name, () => {
 
       metaWriter.write(testDocument, testRoot, meta);
 
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
-      const regex = new RegExp('<office:meta>' +
-        '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>' +
-        '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>' +
-        '<meta:editing-cycles>1</meta:editing-cycles>' +
-        '</office:meta>');
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
+      const regex = new RegExp(
+        '<office:meta>' +
+          '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>' +
+          '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>' +
+          '<meta:editing-cycles>1</meta:editing-cycles>' +
+          '</office:meta>'
+      );
       expect(documentAsString).toMatch(regex);
     });
 
     it('append elements if they are set', () => {
-      meta.setCreator('Homer Simpson')
+      meta
+        .setCreator('Homer Simpson')
         .setDate(new Date(Date.UTC(2020, 11, 24, 13, 37, 23, 42)))
         .setDescription('some test description')
         .setInitialCreator('Marge Simpson')
@@ -67,23 +83,27 @@ describe(MetaWriter.name, () => {
 
       metaWriter.write(testDocument, testRoot, meta);
 
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
-      const regex = new RegExp('<office:meta>' +
-        '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>' +
-        '<dc:title>some test title</dc:title>' +
-        '<dc:description>some test description</dc:description>' +
-        '<dc:subject>some test subject</dc:subject>' +
-        '<meta:keyword>some keyword</meta:keyword>' +
-        '<meta:keyword>some other keyword</meta:keyword>' +
-        '<meta:initial-creator>Marge Simpson</meta:initial-creator>' +
-        '<dc:creator>Homer Simpson</dc:creator>' +
-        '<meta:printed-by>Maggie Simpson</meta:printed-by>' +
-        '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>' +
-        '<dc:date>2020-12-24T13:37:23.042Z</dc:date>' +
-        '<meta:print-date>2021-04-01T00:00:00.000Z</meta:print-date>' +
-        '<dc:language>zu</dc:language>' +
-        '<meta:editing-cycles>1</meta:editing-cycles>' +
-        '</office:meta>');
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
+      const regex = new RegExp(
+        '<office:meta>' +
+          '<meta:generator>simple-odf/\\d\\.\\d+\\.\\d+</meta:generator>' +
+          '<dc:title>some test title</dc:title>' +
+          '<dc:description>some test description</dc:description>' +
+          '<dc:subject>some test subject</dc:subject>' +
+          '<meta:keyword>some keyword</meta:keyword>' +
+          '<meta:keyword>some other keyword</meta:keyword>' +
+          '<meta:initial-creator>Marge Simpson</meta:initial-creator>' +
+          '<dc:creator>Homer Simpson</dc:creator>' +
+          '<meta:printed-by>Maggie Simpson</meta:printed-by>' +
+          '<meta:creation-date>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z</meta:creation-date>' +
+          '<dc:date>2020-12-24T13:37:23.042Z</dc:date>' +
+          '<meta:print-date>2021-04-01T00:00:00.000Z</meta:print-date>' +
+          '<dc:language>zu</dc:language>' +
+          '<meta:editing-cycles>1</meta:editing-cycles>' +
+          '</office:meta>'
+      );
       expect(documentAsString).toMatch(regex);
     });
   });

--- a/src/xml/meta/MetaWriter.ts
+++ b/src/xml/meta/MetaWriter.ts
@@ -16,7 +16,7 @@ export class MetaWriter {
    * @param {Meta} meta The Meta to serialize
    * @since 0.7.0
    */
-  public write (document: Document, root: Element, meta: Meta): void {
+  public write(document: Document, root: Element, meta: Meta): void {
     const metaElement = document.createElement(OdfElementName.OfficeMeta);
     root.appendChild(metaElement);
 
@@ -43,10 +43,18 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setCreationDateElement (document: Document, metaElement: Element, meta: Meta): void {
-    const creationDateElement = document.createElement(MetaElementName.MetaCreationDate);
+  private setCreationDateElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
+    const creationDateElement = document.createElement(
+      MetaElementName.MetaCreationDate
+    );
     metaElement.appendChild(creationDateElement);
-    creationDateElement.appendChild(document.createTextNode(meta.getCreationDate().toISOString()));
+    creationDateElement.appendChild(
+      document.createTextNode(meta.getCreationDate().toISOString())
+    );
   }
 
   /**
@@ -57,7 +65,11 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setCreatorElement (document: Document, metaElement: Element, meta: Meta): void {
+  private setCreatorElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     const creator = meta.getCreator();
     if (creator === undefined || creator.length === 0) {
       return;
@@ -76,7 +88,11 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setDateElement (document: Document, metaElement: Element, meta: Meta): void {
+  private setDateElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     const date = meta.getDate();
     if (date === undefined) {
       return;
@@ -95,13 +111,19 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setDescriptionElement (document: Document, metaElement: Element, meta: Meta): void {
+  private setDescriptionElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     const description = meta.getDescription();
     if (description === undefined || description.length === 0) {
       return;
     }
 
-    const descriptionElement = document.createElement(MetaElementName.DcDescription);
+    const descriptionElement = document.createElement(
+      MetaElementName.DcDescription
+    );
     metaElement.appendChild(descriptionElement);
     descriptionElement.appendChild(document.createTextNode(description));
   }
@@ -114,10 +136,18 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setEditingCyclesElement (document: Document, metaElement: Element, meta: Meta): void {
-    const editingCyclesElement = document.createElement(MetaElementName.MetaEditingCycles);
+  private setEditingCyclesElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
+    const editingCyclesElement = document.createElement(
+      MetaElementName.MetaEditingCycles
+    );
     metaElement.appendChild(editingCyclesElement);
-    editingCyclesElement.appendChild(document.createTextNode(meta.getEditingCycles().toString()));
+    editingCyclesElement.appendChild(
+      document.createTextNode(meta.getEditingCycles().toString())
+    );
   }
 
   /**
@@ -128,8 +158,14 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setGeneratorElement (document: Document, metaElement: Element, meta: Meta): void {
-    const generatorElement = document.createElement(MetaElementName.MetaGenerator);
+  private setGeneratorElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
+    const generatorElement = document.createElement(
+      MetaElementName.MetaGenerator
+    );
     metaElement.appendChild(generatorElement);
     generatorElement.appendChild(document.createTextNode(meta.getGenerator()));
   }
@@ -142,13 +178,19 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setInitialCreatorElement (document: Document, metaElement: Element, meta: Meta): void {
+  private setInitialCreatorElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     const initialCreator = meta.getInitialCreator();
     if (initialCreator === undefined || initialCreator.length === 0) {
       return;
     }
 
-    const creatorElement = document.createElement(MetaElementName.MetaInitialCreator);
+    const creatorElement = document.createElement(
+      MetaElementName.MetaInitialCreator
+    );
     metaElement.appendChild(creatorElement);
     creatorElement.appendChild(document.createTextNode(initialCreator));
   }
@@ -161,9 +203,15 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setKeywordElements (document: Document, metaElement: Element, meta: Meta): void {
+  private setKeywordElements(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     meta.getKeywords().forEach((keyword: string) => {
-      const subjectElement = document.createElement(MetaElementName.MetaKeyword);
+      const subjectElement = document.createElement(
+        MetaElementName.MetaKeyword
+      );
       metaElement.appendChild(subjectElement);
       subjectElement.appendChild(document.createTextNode(keyword));
     });
@@ -177,7 +225,11 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setLanguageElement (document: Document, metaElement: Element, meta: Meta): void {
+  private setLanguageElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     const language = meta.getLanguage();
     if (language === undefined || language.length === 0) {
       return;
@@ -196,15 +248,23 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setPrintDateElement (document: Document, metaElement: Element, meta: Meta): void {
+  private setPrintDateElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     const printDate = meta.getPrintDate();
     if (printDate === undefined) {
       return;
     }
 
-    const printDateElement = document.createElement(MetaElementName.MetaPrintDate);
+    const printDateElement = document.createElement(
+      MetaElementName.MetaPrintDate
+    );
     metaElement.appendChild(printDateElement);
-    printDateElement.appendChild(document.createTextNode(printDate.toISOString()));
+    printDateElement.appendChild(
+      document.createTextNode(printDate.toISOString())
+    );
   }
 
   /**
@@ -215,12 +275,18 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setPrintedByElement (document: Document, metaElement: Element, meta: Meta): void {
+  private setPrintedByElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     const printedBy = meta.getPrintedBy();
     if (printedBy === undefined || printedBy.length === 0) {
       return;
     }
-    const printedByElement = document.createElement(MetaElementName.MetaPrintedBy);
+    const printedByElement = document.createElement(
+      MetaElementName.MetaPrintedBy
+    );
     metaElement.appendChild(printedByElement);
     printedByElement.appendChild(document.createTextNode(printedBy));
   }
@@ -233,7 +299,11 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setSubjectElement (document: Document, metaElement: Element, meta: Meta): void {
+  private setSubjectElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     const subject = meta.getSubject();
     if (subject === undefined || subject.length === 0) {
       return;
@@ -252,7 +322,11 @@ export class MetaWriter {
    * @param {Meta} meta The metadata
    * @private
    */
-  private setTitleElement (document: Document, metaElement: Element, meta: Meta): void {
+  private setTitleElement(
+    document: Document,
+    metaElement: Element,
+    meta: Meta
+  ): void {
     const title = meta.getTitle();
     if (title === undefined || title.length === 0) {
       return;

--- a/src/xml/office/FontFaceDeclarationsWriter.spec.ts
+++ b/src/xml/office/FontFaceDeclarationsWriter.spec.ts
@@ -12,7 +12,11 @@ describe(FontFaceDeclarationsWriter.name, () => {
     let fontFaceDeclarations: FontFaceDeclarations;
 
     beforeEach(() => {
-      testDocument = new DOMImplementation().createDocument('someNameSpace', OdfElementName.OfficeDocument, null);
+      testDocument = new DOMImplementation().createDocument(
+        'someNameSpace',
+        OdfElementName.OfficeDocument,
+        null
+      );
       testRoot = testDocument.firstChild as Element;
       fontFaceDeclarations = new FontFaceDeclarations();
 
@@ -20,28 +24,58 @@ describe(FontFaceDeclarationsWriter.name, () => {
     });
 
     it('do nothing if no font face is defined', () => {
-      fontFaceDeclarationsWriter.write(fontFaceDeclarations, testDocument, testRoot);
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
+      fontFaceDeclarationsWriter.write(
+        fontFaceDeclarations,
+        testDocument,
+        testRoot
+      );
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
 
       expect(documentAsString).not.toMatch(/office:font-face-decls/);
     });
 
     it('add font declaration to document', () => {
-      fontFaceDeclarations.create('Springfield', 'Springfield', FontPitch.Variable);
+      fontFaceDeclarations.create(
+        'Springfield',
+        'Springfield',
+        FontPitch.Variable
+      );
 
-      fontFaceDeclarationsWriter.write(fontFaceDeclarations, testDocument, testRoot);
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
+      fontFaceDeclarationsWriter.write(
+        fontFaceDeclarations,
+        testDocument,
+        testRoot
+      );
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
 
-      expect(documentAsString).toMatch(/<office:font-face-decls><style:font-face style:name="Springfield" svg:font-family="Springfield" style:font-pitch="variable"\/><\/office:font-face-decls>/);
+      expect(documentAsString).toMatch(
+        /<office:font-face-decls><style:font-face style:name="Springfield" svg:font-family="Springfield" style:font-pitch="variable"\/><\/office:font-face-decls>/
+      );
     });
 
     it('add font declaration to document and wrap font family if it contains spaces', () => {
-      fontFaceDeclarations.create('Homer Simpson', 'Homer Simpson', FontPitch.Fixed);
+      fontFaceDeclarations.create(
+        'Homer Simpson',
+        'Homer Simpson',
+        FontPitch.Fixed
+      );
 
-      fontFaceDeclarationsWriter.write(fontFaceDeclarations, testDocument, testRoot);
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
+      fontFaceDeclarationsWriter.write(
+        fontFaceDeclarations,
+        testDocument,
+        testRoot
+      );
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
 
-      expect(documentAsString).toMatch(/<office:font-face-decls><style:font-face style:name="Homer Simpson" svg:font-family="'Homer Simpson'" style:font-pitch="fixed"\/><\/office:font-face-decls>/);
+      expect(documentAsString).toMatch(
+        /<office:font-face-decls><style:font-face style:name="Homer Simpson" svg:font-family="'Homer Simpson'" style:font-pitch="fixed"\/><\/office:font-face-decls>/
+      );
     });
   });
 });

--- a/src/xml/office/FontFaceDeclarationsWriter.ts
+++ b/src/xml/office/FontFaceDeclarationsWriter.ts
@@ -16,14 +16,20 @@ export class FontFaceDeclarationsWriter {
    * @param {FontFaceDeclarations} fontFaceDeclarations The font face declarations to serialize
    * @since 0.7.0
    */
-  public write (fontFaceDeclarations: FontFaceDeclarations, document: Document, root: Element): void {
+  public write(
+    fontFaceDeclarations: FontFaceDeclarations,
+    document: Document,
+    root: Element
+  ): void {
     const fonts = fontFaceDeclarations.getAll();
 
     if (fonts.length === 0) {
       return;
     }
 
-    const fontFaceDeclsElement = document.createElement(OdfElementName.OfficeFontFaceDeclarations);
+    const fontFaceDeclsElement = document.createElement(
+      OdfElementName.OfficeFontFaceDeclarations
+    );
     root.appendChild(fontFaceDeclsElement);
 
     fonts.forEach((font: FontFace) => {
@@ -31,15 +37,22 @@ export class FontFaceDeclarationsWriter {
     });
   }
 
-  private visitFontFace (font: FontFace, document: Document, parent: Element): Element {
-    const fontFaceElement = document.createElement(OdfElementName.StyleFontFace);
+  private visitFontFace(
+    font: FontFace,
+    document: Document,
+    parent: Element
+  ): Element {
+    const fontFaceElement = document.createElement(
+      OdfElementName.StyleFontFace
+    );
     parent.appendChild(fontFaceElement);
 
     fontFaceElement.setAttribute('style:name', font.getName());
 
     const fontFamily = font.getFontFamily();
     if (fontFamily !== undefined) {
-      const encodedFontFamily = fontFamily.includes(' ') === true ? `'${fontFamily}'` : fontFamily;
+      const encodedFontFamily =
+        fontFamily.includes(' ') === true ? `'${fontFamily}'` : fontFamily;
       fontFaceElement.setAttribute('svg:font-family', encodedFontFamily);
     }
 

--- a/src/xml/office/StylesWriter.spec.ts
+++ b/src/xml/office/StylesWriter.spec.ts
@@ -1,12 +1,22 @@
-/* eslint-disable import/no-duplicates */
 import { DOMImplementation, XMLSerializer } from 'xmldom';
 import { CommonStyles, AutomaticStyles } from '../../api/office';
-import { BorderStyle, Color, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine } from '../../api/style';
-import { PageBreak, ParagraphStyle, TabStop, TabStopLeaderStyle, TabStopType } from '../../api/style';
-import { TextTransformation, Typeface, VerticalAlignment } from '../../api/style';
+import {
+  BorderStyle,
+  Color,
+  FontVariant,
+  HorizontalAlignment,
+  HorizontalAlignmentLastLine,
+  PageBreak,
+  ParagraphStyle,
+  TabStop,
+  TabStopLeaderStyle,
+  TabStopType,
+  TextTransformation,
+  Typeface,
+  VerticalAlignment,
+} from '../../api/style';
 import { OdfElementName } from '../OdfElementName';
 import { StylesWriter } from './StylesWriter';
-/* eslint-enable import/no-duplicates */
 
 describe(StylesWriter.name, () => {
   describe('#write', () => {
@@ -16,7 +26,11 @@ describe(StylesWriter.name, () => {
     let commonStyles: CommonStyles;
 
     beforeEach(() => {
-      testDocument = new DOMImplementation().createDocument('someNameSpace', OdfElementName.OfficeDocument, null);
+      testDocument = new DOMImplementation().createDocument(
+        'someNameSpace',
+        OdfElementName.OfficeDocument,
+        null
+      );
       testRoot = testDocument.firstChild as Element;
       commonStyles = new CommonStyles();
 
@@ -25,7 +39,9 @@ describe(StylesWriter.name, () => {
 
     it('do nothing if no style is defined', () => {
       stylesWriter.write(commonStyles, testDocument, testRoot);
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
 
       expect(documentAsString).not.toMatch(/office:styles/);
     });
@@ -34,9 +50,13 @@ describe(StylesWriter.name, () => {
       commonStyles.createParagraphStyle('Summary');
 
       stylesWriter.write(commonStyles, testDocument, testRoot);
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
 
-      expect(documentAsString).toMatch(/<office:styles><style:style style:name="Summary" style:display-name="Summary" style:family="paragraph">.*<\/style:style><\/office:styles>/);
+      expect(documentAsString).toMatch(
+        /<office:styles><style:style style:name="Summary" style:display-name="Summary" style:family="paragraph">.*<\/style:style><\/office:styles>/
+      );
     });
 
     it('add automatic style', () => {
@@ -44,28 +64,39 @@ describe(StylesWriter.name, () => {
       automaticStyles.add(new ParagraphStyle());
 
       stylesWriter.write(automaticStyles, testDocument, testRoot);
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
 
-      expect(documentAsString).toMatch(/<office:automatic-styles><style:style style:name="P1" style:family="paragraph">.*<\/style:style><\/office:automatic-styles>/);
+      expect(documentAsString).toMatch(
+        /<office:automatic-styles><style:style style:name="P1" style:family="paragraph">.*<\/style:style><\/office:automatic-styles>/
+      );
     });
 
     it('add style and set class', () => {
-      commonStyles.createParagraphStyle('Summary')
-        .setClass('someClass');
+      commonStyles.createParagraphStyle('Summary').setClass('someClass');
 
       stylesWriter.write(commonStyles, testDocument, testRoot);
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
 
-      expect(documentAsString).toMatch(/<office:styles><style:style style:name="Summary" style:display-name="Summary" style:family="paragraph" style:class="someClass">.*<\/style:style><\/office:styles>/);
+      expect(documentAsString).toMatch(
+        /<office:styles><style:style style:name="Summary" style:display-name="Summary" style:family="paragraph" style:class="someClass">.*<\/style:style><\/office:styles>/
+      );
     });
 
     it('add paragraph style', () => {
       commonStyles.createParagraphStyle('Summary');
 
       stylesWriter.write(commonStyles, testDocument, testRoot);
-      const documentAsString = new XMLSerializer().serializeToString(testDocument);
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
 
-      expect(documentAsString).toMatch(/<office:styles><style:style style:name="Summary" style:display-name="Summary" style:family="paragraph"><style:paragraph-properties\/><style:text-properties\/><\/style:style><\/office:styles>/);
+      expect(documentAsString).toMatch(
+        /<office:styles><style:style style:name="Summary" style:display-name="Summary" style:family="paragraph"><style:paragraph-properties\/><style:text-properties\/><\/style:style><\/office:styles>/
+      );
     });
 
     describe('paragraph properties', () => {
@@ -79,251 +110,379 @@ describe(StylesWriter.name, () => {
         testStyle.setBackgroundColor(Color.fromRgb(1, 2, 3));
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:background-color="#010203"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:background-color="#010203"\/>/
+        );
       });
 
       it('set border bottom', () => {
-        testStyle.setBorderBottom(23.42, BorderStyle.Dashed, Color.fromRgb(1, 2, 3));
+        testStyle.setBorderBottom(
+          23.42,
+          BorderStyle.Dashed,
+          Color.fromRgb(1, 2, 3)
+        );
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:border-bottom="23.42mm dashed #010203"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:border-bottom="23.42mm dashed #010203"\/>/
+        );
       });
 
       it('set border left', () => {
-        testStyle.setBorderLeft(23.42, BorderStyle.Dotted, Color.fromRgb(1, 2, 3));
+        testStyle.setBorderLeft(
+          23.42,
+          BorderStyle.Dotted,
+          Color.fromRgb(1, 2, 3)
+        );
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:border-left="23.42mm dotted #010203"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:border-left="23.42mm dotted #010203"\/>/
+        );
       });
 
       it('set border right', () => {
-        testStyle.setBorderRight(23.42, BorderStyle.Double, Color.fromRgb(1, 2, 3));
+        testStyle.setBorderRight(
+          23.42,
+          BorderStyle.Double,
+          Color.fromRgb(1, 2, 3)
+        );
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:border-right="23.42mm double #010203"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:border-right="23.42mm double #010203"\/>/
+        );
       });
 
       it('set border top', () => {
-        testStyle.setBorderTop(23.42, BorderStyle.Solid, Color.fromRgb(1, 2, 3));
+        testStyle.setBorderTop(
+          23.42,
+          BorderStyle.Solid,
+          Color.fromRgb(1, 2, 3)
+        );
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:border-top="23.42mm solid #010203"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:border-top="23.42mm solid #010203"\/>/
+        );
       });
 
       it('set horizontal alignment', () => {
         testStyle.setHorizontalAlignment(HorizontalAlignment.Center);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:text-align="center"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:text-align="center"\/>/
+        );
       });
 
       it('set horizontal alignment of last line if horizontal alignment is justify', () => {
-        testStyle.setHorizontalAlignmentLastLine(HorizontalAlignmentLastLine.Center);
+        testStyle.setHorizontalAlignmentLastLine(
+          HorizontalAlignmentLastLine.Center
+        );
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        let documentAsString = new XMLSerializer().serializeToString(testDocument);
+        let documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
         expect(documentAsString).not.toMatch(/fo:text-align-last/);
 
         testStyle.setHorizontalAlignment(HorizontalAlignment.Justify);
-        testStyle.setHorizontalAlignmentLastLine(HorizontalAlignmentLastLine.Center);
+        testStyle.setHorizontalAlignmentLastLine(
+          HorizontalAlignmentLastLine.Center
+        );
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
         documentAsString = new XMLSerializer().serializeToString(testDocument);
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:text-align="justify" fo:text-align-last="center"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:text-align="justify" fo:text-align-last="center"\/>/
+        );
       });
 
       it('set keep together', () => {
         testStyle.setKeepTogether(true);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:keep-together="always"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:keep-together="always"\/>/
+        );
       });
 
       it('set keep with next', () => {
         testStyle.setKeepWithNext(true);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:keep-with-next="always"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:keep-with-next="always"\/>/
+        );
       });
 
       it('set line height as fix value', () => {
         testStyle.setLineHeight(23);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:line-height="23mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:line-height="23mm"\/>/
+        );
       });
 
       it('set line height as percentage', () => {
         testStyle.setLineHeight('42%');
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:line-height="42%"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:line-height="42%"\/>/
+        );
       });
 
       it('set line height at least', () => {
         testStyle.setLineHeightAtLeast(23);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties style:line-height-at-least="23mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties style:line-height-at-least="23mm"\/>/
+        );
       });
 
       it('set line spacing', () => {
         testStyle.setLineSpacing(23);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties style:line-spacing="23mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties style:line-spacing="23mm"\/>/
+        );
       });
 
       it('set margin bottom', () => {
         testStyle.setMarginBottom(23.42);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:margin-bottom="23.42mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:margin-bottom="23.42mm"\/>/
+        );
       });
 
       it('set margin left', () => {
         testStyle.setMarginLeft(23.42);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:margin-left="23.42mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:margin-left="23.42mm"\/>/
+        );
       });
 
       it('set margin right', () => {
         testStyle.setMarginRight(23.42);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:margin-right="23.42mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:margin-right="23.42mm"\/>/
+        );
       });
 
       it('set margin top', () => {
         testStyle.setMarginTop(23.42);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:margin-top="23.42mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:margin-top="23.42mm"\/>/
+        );
       });
 
       it('set orphans', () => {
         testStyle.setOrphans(23);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:orphans="23"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:orphans="23"\/>/
+        );
       });
 
       it('set padding bottom', () => {
         testStyle.setPaddingBottom(23.42);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:padding-bottom="23.42mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:padding-bottom="23.42mm"\/>/
+        );
       });
 
       it('set padding left', () => {
         testStyle.setPaddingLeft(23.42);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:padding-left="23.42mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:padding-left="23.42mm"\/>/
+        );
       });
 
       it('set padding right', () => {
         testStyle.setPaddingRight(23.42);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:padding-right="23.42mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:padding-right="23.42mm"\/>/
+        );
       });
 
       it('set padding top', () => {
         testStyle.setPaddingTop(23.42);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:padding-top="23.42mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:padding-top="23.42mm"\/>/
+        );
       });
 
       it('set page break before', () => {
         testStyle.setPageBreak(PageBreak.Before);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:break-before="page"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:break-before="page"\/>/
+        );
       });
 
       it('set page break after', () => {
         testStyle.setPageBreak(PageBreak.After);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:break-after="page"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:break-after="page"\/>/
+        );
       });
 
       it('set text indent', () => {
         testStyle.setTextIndent(23.42);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:text-indent="23.42mm"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:text-indent="23.42mm"\/>/
+        );
       });
 
       it('set vertical alignment', () => {
         testStyle.setVerticalAlignment(VerticalAlignment.Middle);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties style:vertical-align="middle"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties style:vertical-align="middle"\/>/
+        );
       });
 
       it('set widows', () => {
         testStyle.setWidows(23);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:paragraph-properties fo:widows="23"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:paragraph-properties fo:widows="23"\/>/
+        );
       });
 
       describe('tab stops', () => {
@@ -331,9 +490,13 @@ describe(StylesWriter.name, () => {
           testStyle.addTabStop(new TabStop(2, TabStopType.Left));
 
           stylesWriter.write(commonStyles, testDocument, testRoot);
-          const documentAsString = new XMLSerializer().serializeToString(testDocument);
+          const documentAsString = new XMLSerializer().serializeToString(
+            testDocument
+          );
 
-          expect(documentAsString).toMatch(/<style:paragraph-properties><style:tab-stops><style:tab-stop style:position="2mm"\/><\/style:tab-stops><\/style:paragraph-properties>/);
+          expect(documentAsString).toMatch(
+            /<style:paragraph-properties><style:tab-stops><style:tab-stop style:position="2mm"\/><\/style:tab-stops><\/style:paragraph-properties>/
+          );
         });
 
         it('set tab stop types', () => {
@@ -344,30 +507,56 @@ describe(StylesWriter.name, () => {
           testStyle.addTabStop(new TabStop(8, TabStopType.Right));
 
           stylesWriter.write(commonStyles, testDocument, testRoot);
-          const documentAsString = new XMLSerializer().serializeToString(testDocument);
+          const documentAsString = new XMLSerializer().serializeToString(
+            testDocument
+          );
 
-          expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center"\/>/);
-          expect(documentAsString).toMatch(/<style:tab-stop style:position="4mm" style:type="char" style:char="~"\/>/);
-          expect(documentAsString).toMatch(/<style:tab-stop style:position="6mm"\/>/);
-          expect(documentAsString).toMatch(/<style:tab-stop style:position="8mm" style:type="right"\/>/);
+          expect(documentAsString).toMatch(
+            /<style:tab-stop style:position="2mm" style:type="center"\/>/
+          );
+          expect(documentAsString).toMatch(
+            /<style:tab-stop style:position="4mm" style:type="char" style:char="~"\/>/
+          );
+          expect(documentAsString).toMatch(
+            /<style:tab-stop style:position="6mm"\/>/
+          );
+          expect(documentAsString).toMatch(
+            /<style:tab-stop style:position="8mm" style:type="right"\/>/
+          );
         });
 
         it('set leader style', () => {
-          testStyle.addTabStop(new TabStop(2, TabStopType.Center).setLeaderStyle(TabStopLeaderStyle.Dotted));
+          testStyle.addTabStop(
+            new TabStop(2, TabStopType.Center).setLeaderStyle(
+              TabStopLeaderStyle.Dotted
+            )
+          );
 
           stylesWriter.write(commonStyles, testDocument, testRoot);
-          const documentAsString = new XMLSerializer().serializeToString(testDocument);
+          const documentAsString = new XMLSerializer().serializeToString(
+            testDocument
+          );
 
-          expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center" style:leader-style="dotted"\/>/);
+          expect(documentAsString).toMatch(
+            /<style:tab-stop style:position="2mm" style:type="center" style:leader-style="dotted"\/>/
+          );
         });
 
         it('set leader color', () => {
-          testStyle.addTabStop(new TabStop(2, TabStopType.Center).setLeaderColor(Color.fromRgb(1, 2, 3)));
+          testStyle.addTabStop(
+            new TabStop(2, TabStopType.Center).setLeaderColor(
+              Color.fromRgb(1, 2, 3)
+            )
+          );
 
           stylesWriter.write(commonStyles, testDocument, testRoot);
-          const documentAsString = new XMLSerializer().serializeToString(testDocument);
+          const documentAsString = new XMLSerializer().serializeToString(
+            testDocument
+          );
 
-          expect(documentAsString).toMatch(/<style:tab-stop style:position="2mm" style:type="center" style:leader-color="#010203"\/>/);
+          expect(documentAsString).toMatch(
+            /<style:tab-stop style:position="2mm" style:type="center" style:leader-color="#010203"\/>/
+          );
         });
       });
     });
@@ -383,90 +572,130 @@ describe(StylesWriter.name, () => {
         testStyle.setColor(Color.fromRgb(1, 2, 3));
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties fo:color="#010203"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties fo:color="#010203"\/>/
+        );
       });
 
       it('set font name', () => {
         testStyle.setFontName('someFontName');
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties style:font-name="someFontName"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties style:font-name="someFontName"\/>/
+        );
       });
 
       it('set font size', () => {
         testStyle.setFontSize(23);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties fo:font-size="23pt"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties fo:font-size="23pt"\/>/
+        );
       });
 
       it('set font variant', () => {
         testStyle.setFontVariant(FontVariant.SmallCaps);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties fo:font-variant="small-caps"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties fo:font-variant="small-caps"\/>/
+        );
       });
 
       it('set text transformation', () => {
         testStyle.setTextTransformation(TextTransformation.Capitalize);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties fo:text-transform="capitalize"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties fo:text-transform="capitalize"\/>/
+        );
       });
 
       it('set the font-style for italic', () => {
         testStyle.setTypeface(Typeface.Italic);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties fo:font-style="italic"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties fo:font-style="italic"\/>/
+        );
       });
 
       it('set the font-style for oblique', () => {
         testStyle.setTypeface(Typeface.Oblique);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties fo:font-style="oblique"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties fo:font-style="oblique"\/>/
+        );
       });
 
       it('set the font-weight for bold', () => {
         testStyle.setTypeface(Typeface.Bold);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties fo:font-weight="bold"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties fo:font-weight="bold"\/>/
+        );
       });
 
       it('set the font-style and font-weight for bold-italic', () => {
         testStyle.setTypeface(Typeface.BoldItalic);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties fo:font-style="italic" fo:font-weight="bold"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties fo:font-style="italic" fo:font-weight="bold"\/>/
+        );
       });
 
       it('set the font-style and font-weight for bold-oblique', () => {
         testStyle.setTypeface(Typeface.BoldOblique);
 
         stylesWriter.write(commonStyles, testDocument, testRoot);
-        const documentAsString = new XMLSerializer().serializeToString(testDocument);
+        const documentAsString = new XMLSerializer().serializeToString(
+          testDocument
+        );
 
-        expect(documentAsString).toMatch(/<style:text-properties fo:font-style="oblique" fo:font-weight="bold"\/>/);
+        expect(documentAsString).toMatch(
+          /<style:text-properties fo:font-style="oblique" fo:font-weight="bold"\/>/
+        );
       });
     });
   });

--- a/src/xml/office/StylesWriter.ts
+++ b/src/xml/office/StylesWriter.ts
@@ -1,11 +1,21 @@
-/* eslint-disable import/no-duplicates */
 import { AutomaticStyles, CommonStyles, IStyles } from '../../api/office';
-import { BorderStyle, FontVariant, HorizontalAlignment, HorizontalAlignmentLastLine, PageBreak } from '../../api/style';
-import { ParagraphStyle, Style, StyleFamily, TabStopLeaderStyle, TabStopType } from '../../api/style';
-import { TextTransformation, Typeface, VerticalAlignment } from '../../api/style';
+import {
+  BorderStyle,
+  FontVariant,
+  HorizontalAlignment,
+  HorizontalAlignmentLastLine,
+  PageBreak,
+  ParagraphStyle,
+  Style,
+  StyleFamily,
+  TabStopLeaderStyle,
+  TabStopType,
+  TextTransformation,
+  Typeface,
+  VerticalAlignment,
+} from '../../api/style';
 import { OdfAttributeName } from '../OdfAttributeName';
 import { OdfElementName } from '../OdfElementName';
-/* eslint-enable import/no-duplicates */
 
 /**
  * Transforms a {@link StyleManager} object into ODF conform XML
@@ -23,27 +33,40 @@ export class StylesWriter {
    * @param {Element} parent The parent node in the DOM
    * @since 0.7.0
    */
-  public write (styles: IStyles, document: Document, root: Element): void {
+  public write(styles: IStyles, document: Document, root: Element): void {
     const allStyles = styles.getAll();
 
     if (allStyles.length === 0) {
       return;
     }
 
-    const tagName = styles instanceof CommonStyles ? OdfElementName.OfficeStyles : OdfElementName.OfficeAutomaticStyles;
+    const tagName =
+      styles instanceof CommonStyles
+        ? OdfElementName.OfficeStyles
+        : OdfElementName.OfficeAutomaticStyles;
     const stylesElement = document.createElement(tagName);
     root.appendChild(stylesElement);
 
-    allStyles.forEach((style) => this.visitStyle(style, styles, document, stylesElement));
+    allStyles.forEach((style) =>
+      this.visitStyle(style, styles, document, stylesElement)
+    );
   }
 
-  private visitStyle (style: Style, styles: IStyles, document: Document, parent: Element): Element {
+  private visitStyle(
+    style: Style,
+    styles: IStyles,
+    document: Document,
+    parent: Element
+  ): Element {
     const styleElement = document.createElement(OdfElementName.StyleStyle);
     parent.appendChild(styleElement);
 
     const styleName = style.getName();
     if (styleName === Style.UNNAMED) {
-      styleElement.setAttribute('style:name', (styles as AutomaticStyles).getName(style));
+      styleElement.setAttribute(
+        'style:name',
+        (styles as AutomaticStyles).getName(style)
+      );
     } else {
       styleElement.setAttribute('style:name', style.getName());
       styleElement.setAttribute('style:display-name', style.getDisplayName());
@@ -58,8 +81,16 @@ export class StylesWriter {
 
     switch (style.getFamily()) {
       case StyleFamily.Paragraph:
-        this.visitParagraphProperties(style as ParagraphStyle, document, styleElement);
-        this.visitTextProperties(style as ParagraphStyle, document, styleElement);
+        this.visitParagraphProperties(
+          style as ParagraphStyle,
+          document,
+          styleElement
+        );
+        this.visitTextProperties(
+          style as ParagraphStyle,
+          document,
+          styleElement
+        );
         break;
       default:
         break;
@@ -68,17 +99,29 @@ export class StylesWriter {
     return styleElement;
   }
 
-  private visitParagraphProperties (style: ParagraphStyle, document: Document, parent: Element): Element {
-    const paragraphPropertiesElement = document.createElement(OdfElementName.StyleParagraphProperties);
+  private visitParagraphProperties(
+    style: ParagraphStyle,
+    document: Document,
+    parent: Element
+  ): Element {
+    const paragraphPropertiesElement = document.createElement(
+      OdfElementName.StyleParagraphProperties
+    );
     parent.appendChild(paragraphPropertiesElement);
 
     const lineHeight = style.getLineHeight();
     switch (typeof lineHeight) {
       case 'number':
-        paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatLineHeight, lineHeight + 'mm');
+        paragraphPropertiesElement.setAttribute(
+          OdfAttributeName.FormatLineHeight,
+          lineHeight + 'mm'
+        );
         break;
       case 'string':
-        paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatLineHeight, lineHeight);
+        paragraphPropertiesElement.setAttribute(
+          OdfAttributeName.FormatLineHeight,
+          lineHeight
+        );
         break;
       default:
         break;
@@ -86,70 +129,114 @@ export class StylesWriter {
 
     const lineHeightAtLeast = style.getLineHeightAtLeast();
     if (lineHeightAtLeast !== undefined) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.StyleLineHeightAtLeast, lineHeightAtLeast + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.StyleLineHeightAtLeast,
+        lineHeightAtLeast + 'mm'
+      );
     }
 
     const lineSpacing = style.getLineSpacing();
     if (lineSpacing !== undefined) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.StyleLineSpacing, lineSpacing + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.StyleLineSpacing,
+        lineSpacing + 'mm'
+      );
     }
 
     const horizontalAlignment = style.getHorizontalAlignment();
     if (horizontalAlignment !== HorizontalAlignment.Default) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatTextAlign, horizontalAlignment);
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatTextAlign,
+        horizontalAlignment
+      );
     }
 
     const horizontalAlignmentLastLine = style.getHorizontalAlignmentLastLine();
-    if (horizontalAlignment === HorizontalAlignment.Justify &&
-      horizontalAlignmentLastLine !== HorizontalAlignmentLastLine.Default) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatTextAlignLast, horizontalAlignmentLastLine);
+    if (
+      horizontalAlignment === HorizontalAlignment.Justify &&
+      horizontalAlignmentLastLine !== HorizontalAlignmentLastLine.Default
+    ) {
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatTextAlignLast,
+        horizontalAlignmentLastLine
+      );
     }
 
     if (style.getKeepTogether() === true) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatKeepTogether, 'always');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatKeepTogether,
+        'always'
+      );
     }
 
     const widows = style.getWidows();
     if (widows !== undefined) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatWidows, widows.toString(10));
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatWidows,
+        widows.toString(10)
+      );
     }
 
     const orphans = style.getOrphans();
     if (orphans !== undefined) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatOrphans, orphans.toString(10));
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatOrphans,
+        orphans.toString(10)
+      );
     }
 
     const marginLeft = style.getMarginLeft();
     if (marginLeft !== 0) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatMarginLeft, marginLeft.toString(10) + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatMarginLeft,
+        marginLeft.toString(10) + 'mm'
+      );
     }
 
     const marginRight = style.getMarginRight();
     if (marginRight !== 0) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatMarginRight, marginRight.toString(10) + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatMarginRight,
+        marginRight.toString(10) + 'mm'
+      );
     }
 
     const textIndent = style.getTextIndent();
     if (textIndent !== 0) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatTextIndent, textIndent.toString(10) + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatTextIndent,
+        textIndent.toString(10) + 'mm'
+      );
     }
 
     const marginTop = style.getMarginTop();
     if (marginTop !== 0) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatMarginTop, marginTop.toString(10) + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatMarginTop,
+        marginTop.toString(10) + 'mm'
+      );
     }
 
     const marginBottom = style.getMarginBottom();
     if (marginBottom !== 0) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatMarginBottom, marginBottom.toString(10) + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatMarginBottom,
+        marginBottom.toString(10) + 'mm'
+      );
     }
 
     switch (style.getPageBreak()) {
       case PageBreak.Before:
-        paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBreakBefore, 'page');
+        paragraphPropertiesElement.setAttribute(
+          OdfAttributeName.FormatBreakBefore,
+          'page'
+        );
         break;
       case PageBreak.After:
-        paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBreakAfter, 'page');
+        paragraphPropertiesElement.setAttribute(
+          OdfAttributeName.FormatBreakAfter,
+          'page'
+        );
         break;
       default:
         break;
@@ -157,59 +244,116 @@ export class StylesWriter {
 
     const backgroundColor = style.getBackgroundColor();
     if (backgroundColor !== undefined) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBackgroundColor, backgroundColor.toHex());
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatBackgroundColor,
+        backgroundColor.toHex()
+      );
     }
 
     const borderTop = style.getBorderTop();
-    if (borderTop !== undefined && borderTop.width > 0 && borderTop.style !== BorderStyle.None) {
-      const border = `${borderTop.width}mm ${borderTop.style} ${borderTop.color.toHex()}`;
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBorderTop, border);
+    if (
+      borderTop !== undefined &&
+      borderTop.width > 0 &&
+      borderTop.style !== BorderStyle.None
+    ) {
+      const border = `${borderTop.width}mm ${
+        borderTop.style
+      } ${borderTop.color.toHex()}`;
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatBorderTop,
+        border
+      );
     }
 
     const borderBottom = style.getBorderBottom();
-    if (borderBottom !== undefined && borderBottom.width > 0 && borderBottom.style !== BorderStyle.None) {
-      const border = `${borderBottom.width}mm ${borderBottom.style} ${borderBottom.color.toHex()}`;
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBorderBottom, border);
+    if (
+      borderBottom !== undefined &&
+      borderBottom.width > 0 &&
+      borderBottom.style !== BorderStyle.None
+    ) {
+      const border = `${borderBottom.width}mm ${
+        borderBottom.style
+      } ${borderBottom.color.toHex()}`;
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatBorderBottom,
+        border
+      );
     }
 
     const borderLeft = style.getBorderLeft();
-    if (borderLeft !== undefined && borderLeft.width > 0 && borderLeft.style !== BorderStyle.None) {
-      const border = `${borderLeft.width}mm ${borderLeft.style} ${borderLeft.color.toHex()}`;
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBorderLeft, border);
+    if (
+      borderLeft !== undefined &&
+      borderLeft.width > 0 &&
+      borderLeft.style !== BorderStyle.None
+    ) {
+      const border = `${borderLeft.width}mm ${
+        borderLeft.style
+      } ${borderLeft.color.toHex()}`;
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatBorderLeft,
+        border
+      );
     }
 
     const borderRight = style.getBorderRight();
-    if (borderRight !== undefined && borderRight.width > 0 && borderRight.style !== BorderStyle.None) {
-      const border = `${borderRight.width}mm ${borderRight.style} ${borderRight.color.toHex()}`;
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatBorderRight, border);
+    if (
+      borderRight !== undefined &&
+      borderRight.width > 0 &&
+      borderRight.style !== BorderStyle.None
+    ) {
+      const border = `${borderRight.width}mm ${
+        borderRight.style
+      } ${borderRight.color.toHex()}`;
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatBorderRight,
+        border
+      );
     }
 
     const paddingLeft = style.getPaddingLeft();
     if (paddingLeft !== 0) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatPaddingLeft, paddingLeft.toString(10) + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatPaddingLeft,
+        paddingLeft.toString(10) + 'mm'
+      );
     }
 
     const paddingRight = style.getPaddingRight();
     if (paddingRight !== 0) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatPaddingRight, paddingRight.toString(10) + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatPaddingRight,
+        paddingRight.toString(10) + 'mm'
+      );
     }
 
     const paddingTop = style.getPaddingTop();
     if (paddingTop !== 0) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatPaddingTop, paddingTop.toString(10) + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatPaddingTop,
+        paddingTop.toString(10) + 'mm'
+      );
     }
 
     const paddingBottom = style.getPaddingBottom();
     if (paddingBottom !== 0) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatPaddingBottom, paddingBottom.toString(10) + 'mm');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatPaddingBottom,
+        paddingBottom.toString(10) + 'mm'
+      );
     }
 
     if (style.getKeepWithNext() === true) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.FormatKeepWithNext, 'always');
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.FormatKeepWithNext,
+        'always'
+      );
     }
 
     if (style.getVerticalAlignment() !== VerticalAlignment.Default) {
-      paragraphPropertiesElement.setAttribute(OdfAttributeName.StyleVerticalAlign, style.getVerticalAlignment());
+      paragraphPropertiesElement.setAttribute(
+        OdfAttributeName.StyleVerticalAlign,
+        style.getVerticalAlignment()
+      );
     }
 
     const tabStops = style.getTabStops();
@@ -217,14 +361,21 @@ export class StylesWriter {
       return paragraphPropertiesElement;
     }
 
-    const tabStopsElement = document.createElement(OdfElementName.StyleTabStops);
+    const tabStopsElement = document.createElement(
+      OdfElementName.StyleTabStops
+    );
     paragraphPropertiesElement.appendChild(tabStopsElement);
 
     tabStops.forEach((tabStop) => {
-      const tabStopElement = document.createElement(OdfElementName.StyleTabStop);
+      const tabStopElement = document.createElement(
+        OdfElementName.StyleTabStop
+      );
       tabStopsElement.appendChild(tabStopElement);
 
-      tabStopElement.setAttribute(OdfAttributeName.StylePosition, tabStop.getPosition() + 'mm');
+      tabStopElement.setAttribute(
+        OdfAttributeName.StylePosition,
+        tabStop.getPosition() + 'mm'
+      );
 
       const type = tabStop.getType();
       const char = tabStop.getChar();
@@ -237,63 +388,106 @@ export class StylesWriter {
 
       const leaderStyle = tabStop.getLeaderStyle();
       if (leaderStyle !== TabStopLeaderStyle.None) {
-        tabStopElement.setAttribute(OdfAttributeName.StyleLeaderStyle, leaderStyle);
+        tabStopElement.setAttribute(
+          OdfAttributeName.StyleLeaderStyle,
+          leaderStyle
+        );
       }
 
       const leaderColor = tabStop.getLeaderColor();
       if (leaderColor !== undefined) {
-        tabStopElement.setAttribute(OdfAttributeName.StyleLeaderColor, leaderColor.toHex());
+        tabStopElement.setAttribute(
+          OdfAttributeName.StyleLeaderColor,
+          leaderColor.toHex()
+        );
       }
     });
 
     return paragraphPropertiesElement;
   }
 
-  private visitTextProperties (style: ParagraphStyle, document: Document, parent: Element): Element {
-    const textPropertiesElement = document.createElement(OdfElementName.StyleTextProperties);
+  private visitTextProperties(
+    style: ParagraphStyle,
+    document: Document,
+    parent: Element
+  ): Element {
+    const textPropertiesElement = document.createElement(
+      OdfElementName.StyleTextProperties
+    );
     parent.appendChild(textPropertiesElement);
 
     const fontVariant = style.getFontVariant();
     if (fontVariant !== FontVariant.Normal) {
-      textPropertiesElement.setAttribute(OdfAttributeName.FormatFontVariant, fontVariant);
+      textPropertiesElement.setAttribute(
+        OdfAttributeName.FormatFontVariant,
+        fontVariant
+      );
     }
 
     const textTransformation = style.getTextTransformation();
     if (textTransformation !== TextTransformation.None) {
-      textPropertiesElement.setAttribute(OdfAttributeName.FormatTextTransform, textTransformation);
+      textPropertiesElement.setAttribute(
+        OdfAttributeName.FormatTextTransform,
+        textTransformation
+      );
     }
 
     const color = style.getColor();
     if (color !== undefined) {
-      textPropertiesElement.setAttribute(OdfAttributeName.FormatColor, color.toHex());
+      textPropertiesElement.setAttribute(
+        OdfAttributeName.FormatColor,
+        color.toHex()
+      );
     }
 
     const fontName = style.getFontName();
     if (fontName !== undefined) {
-      textPropertiesElement.setAttribute(OdfAttributeName.StyleFontName, fontName);
+      textPropertiesElement.setAttribute(
+        OdfAttributeName.StyleFontName,
+        fontName
+      );
     }
 
     const fontSize = style.getFontSize();
     if (fontSize !== 12) {
-      textPropertiesElement.setAttribute(OdfAttributeName.FormatFontSize, fontSize + 'pt');
+      textPropertiesElement.setAttribute(
+        OdfAttributeName.FormatFontSize,
+        fontSize + 'pt'
+      );
     }
 
     const typeface = style.getTypeface();
     if (typeface === Typeface.Italic || typeface === Typeface.BoldItalic) {
-      textPropertiesElement.setAttribute(OdfAttributeName.FormatFontStyle, 'italic');
+      textPropertiesElement.setAttribute(
+        OdfAttributeName.FormatFontStyle,
+        'italic'
+      );
     }
 
     if (typeface === Typeface.Oblique || typeface === Typeface.BoldOblique) {
-      textPropertiesElement.setAttribute(OdfAttributeName.FormatFontStyle, 'oblique');
+      textPropertiesElement.setAttribute(
+        OdfAttributeName.FormatFontStyle,
+        'oblique'
+      );
     }
 
-    if (typeface === Typeface.Bold || typeface === Typeface.BoldItalic || typeface === Typeface.BoldOblique) {
-      textPropertiesElement.setAttribute(OdfAttributeName.FormatFontWeight, 'bold');
+    if (
+      typeface === Typeface.Bold ||
+      typeface === Typeface.BoldItalic ||
+      typeface === Typeface.BoldOblique
+    ) {
+      textPropertiesElement.setAttribute(
+        OdfAttributeName.FormatFontWeight,
+        'bold'
+      );
     }
 
     const backgroundColor = style.getBackgroundColor();
     if (backgroundColor !== undefined && !(style instanceof ParagraphStyle)) {
-      textPropertiesElement.setAttribute(OdfAttributeName.FormatBackgroundColor, backgroundColor.toHex());
+      textPropertiesElement.setAttribute(
+        OdfAttributeName.FormatBackgroundColor,
+        backgroundColor.toHex()
+      );
     }
 
     return textPropertiesElement;

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -1,13 +1,23 @@
-/* eslint-disable import/no-duplicates */
 import { unlink } from 'fs';
 import { join } from 'path';
 import { promisify } from 'util';
 import { AnchorType } from '../src/api/draw';
 import { TextBody, TextDocument } from '../src/api/office';
-import { BorderStyle, Color, FontPitch, FontVariant, HorizontalAlignment } from '../src/api/style';
-import { HorizontalAlignmentLastLine, PageBreak, ParagraphStyle, TabStop, TabStopType } from '../src/api/style';
-import { TextTransformation, Typeface, VerticalAlignment } from '../src/api/style';
-/* eslint-enable import/no-duplicates */
+import {
+  BorderStyle,
+  Color,
+  FontPitch,
+  FontVariant,
+  HorizontalAlignment,
+  HorizontalAlignmentLastLine,
+  PageBreak,
+  ParagraphStyle,
+  TabStop,
+  TabStopType,
+  TextTransformation,
+  Typeface,
+  VerticalAlignment,
+} from '../src/api/style';
 
 const FILEPATH = './integration.fodt';
 
@@ -29,14 +39,18 @@ xdescribe('integration', () => {
   });
 
   it('metadata', () => {
-    document.getMeta()
+    document
+      .getMeta()
       .setInitialCreator('Marge Simpson')
       .setCreator('Homer Simpson')
       .setLanguage('en-US')
       .setTitle('simple-odf')
       .setSubject('ODF document creation')
-      .setDescription('ODF text document created with Node.js powered by simple-odf')
-      .addKeyword('Simpson').addKeyword('Springfield');
+      .setDescription(
+        'ODF text document created with Node.js powered by simple-odf'
+      )
+      .addKeyword('Simpson')
+      .addKeyword('Springfield');
   });
 
   it('image', () => {
@@ -55,7 +69,9 @@ xdescribe('integration', () => {
     body.addHeading('First heading');
     body.addHeading('Second heading', 2);
 
-    const para = body.addParagraph('The quick, brown fox jumps over a lazy dog.');
+    const para = body.addParagraph(
+      'The quick, brown fox jumps over a lazy dog.'
+    );
     para.addText('\nSome more text');
   });
 
@@ -72,7 +88,9 @@ xdescribe('integration', () => {
       const style = new ParagraphStyle();
       style.setBackgroundColor(Color.fromRgb(0, 255, 0));
 
-      const paragraph = body.addParagraph('Some text with green colored background');
+      const paragraph = body.addParagraph(
+        'Some text with green colored background'
+      );
       paragraph.setStyle(style);
     });
 
@@ -83,7 +101,9 @@ xdescribe('integration', () => {
       style.setBorderLeft(3, BorderStyle.Double, Color.fromRgb(0, 255, 0));
       style.setBorderRight(4, BorderStyle.Solid, Color.fromRgb(0, 0, 255));
 
-      const paragraph = body.addParagraph('Some text with different borders on all sides');
+      const paragraph = body.addParagraph(
+        'Some text with different borders on all sides'
+      );
       paragraph.setStyle(style);
     });
 
@@ -100,8 +120,10 @@ xdescribe('integration', () => {
       style.setHorizontalAlignment(HorizontalAlignment.Justify);
       style.setHorizontalAlignmentLastLine(HorizontalAlignmentLastLine.Center);
 
-      const paragraph = body.addParagraph('Some justified text' +
-        ' (with a lot of text to make sure it does not fit into a single line) with a centered last line');
+      const paragraph = body.addParagraph(
+        'Some justified text' +
+          ' (with a lot of text to make sure it does not fit into a single line) with a centered last line'
+      );
       paragraph.setStyle(style);
     });
 
@@ -133,7 +155,9 @@ xdescribe('integration', () => {
       const style = new ParagraphStyle();
       style.setLineHeightAtLeast(40);
 
-      const paragraph = body.addParagraph('Some text with minimum line height of 40 mm');
+      const paragraph = body.addParagraph(
+        'Some text with minimum line height of 40 mm'
+      );
       paragraph.setStyle(style);
     });
 
@@ -141,7 +165,9 @@ xdescribe('integration', () => {
       const style = new ParagraphStyle();
       style.setLineSpacing(20);
 
-      const paragraph = body.addParagraph('Some text with line spacinh of 20 mm');
+      const paragraph = body.addParagraph(
+        'Some text with line spacinh of 20 mm'
+      );
       paragraph.setStyle(style);
     });
 
@@ -152,13 +178,17 @@ xdescribe('integration', () => {
       style1.setMarginTop(30);
       style1.setMarginBottom(40);
 
-      const paragraph1 = body.addParagraph('Some text with margins on all four sides');
+      const paragraph1 = body.addParagraph(
+        'Some text with margins on all four sides'
+      );
       paragraph1.setStyle(style1);
 
       const style2 = new ParagraphStyle();
       style2.setMargin(10, 20, 30, 40);
 
-      const paragraph2 = body.addParagraph('Some other text with margins on all four sides but set at the same time');
+      const paragraph2 = body.addParagraph(
+        'Some other text with margins on all four sides but set at the same time'
+      );
       paragraph2.setStyle(style2);
     });
 
@@ -166,7 +196,9 @@ xdescribe('integration', () => {
       const style = new ParagraphStyle();
       style.setOrphans(2);
 
-      const paragraph = body.addParagraph('Break paragraph after 2 lines of text at the earliest');
+      const paragraph = body.addParagraph(
+        'Break paragraph after 2 lines of text at the earliest'
+      );
       paragraph.setStyle(style);
     });
 
@@ -177,13 +209,17 @@ xdescribe('integration', () => {
       style1.setPaddingTop(30);
       style1.setPaddingBottom(40);
 
-      const paragraph1 = body.addParagraph('Some text with padding on all four sides');
+      const paragraph1 = body.addParagraph(
+        'Some text with padding on all four sides'
+      );
       paragraph1.setStyle(style1);
 
       const style2 = new ParagraphStyle();
       style2.setPadding(10, 20, 30, 40);
 
-      const paragraph2 = body.addParagraph('Some other text with padding on all four sides but set at the same time');
+      const paragraph2 = body.addParagraph(
+        'Some other text with padding on all four sides but set at the same time'
+      );
       paragraph2.setStyle(style2);
     });
 
@@ -191,7 +227,9 @@ xdescribe('integration', () => {
       const style = new ParagraphStyle();
       style.setTextIndent(23);
 
-      const paragraph = body.addParagraph('First line is indented\nwhile the others are not');
+      const paragraph = body.addParagraph(
+        'First line is indented\nwhile the others are not'
+      );
       paragraph.setStyle(style);
     });
 
@@ -207,7 +245,9 @@ xdescribe('integration', () => {
       const style = new ParagraphStyle();
       style.setWidows(2);
 
-      const paragraph = body.addParagraph('Write at least 2 lines of text after a break of the paragraph');
+      const paragraph = body.addParagraph(
+        'Write at least 2 lines of text after a break of the paragraph'
+      );
       paragraph.setStyle(style);
     });
 
@@ -239,7 +279,9 @@ xdescribe('integration', () => {
     });
 
     it('font name', () => {
-      document.getFontFaceDeclarations().create('Open Sans', 'Open Sans', FontPitch.Variable);
+      document
+        .getFontFaceDeclarations()
+        .create('Open Sans', 'Open Sans', FontPitch.Variable);
 
       const style = new ParagraphStyle();
       style.setFontName('Open Sans');


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please provide a description above and answer the questions below.

Bug fixes and new features must include tests.

If this is your first contribution, don't forget to add your name to the contributors list in the package.json.
-->

**What kind of change is this PR?**

chore

**What is the current behavior?**

The code is formatted according to [standard](https://standardjs.com/).

**What is the new behavior (if this is a feature change)?**

[prettier](https://prettier.io/) is used for code formatting.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Changelog has been updated
- [ ] Fix/Feature: JSDocs have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass
