### PR TITLE
chore(deps): upgrade to typescript 3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1826,9 +1826,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-      "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ==",
+      "version": "10.17.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+      "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -13780,9 +13780,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-odf",
-  "version": "0.10.1",
+  "version": "1.0.0",
   "description": "Open Document Format made easy using pure JavaScript and Node.js",
   "keywords": [
     "open",
@@ -55,7 +55,7 @@
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "@types/jest": "^25.1.0",
-    "@types/node": "^10.17.17",
+    "@types/node": "^10.17.26",
     "@types/xmldom": "^0.1.29",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
@@ -67,7 +67,7 @@
     "prettier": "2.0.5",
     "semantic-release": "^17.0.7",
     "ts-jest": "^25.0.0",
-    "typescript": "^3.3.3"
+    "typescript": "^3.9.5"
   },
   "engines": {
     "node": "^10.x"

--- a/src/api/office/AutomaticStyles.ts
+++ b/src/api/office/AutomaticStyles.ts
@@ -136,7 +136,7 @@ export class AutomaticStyles implements IStyles {
   private getHash(style: Style): string {
     const hash = createHash('md5');
 
-    hash.update(style.getClass() || '');
+    hash.update(style.getClass() ?? '');
     hash.update(style.getFamily());
 
     if (style instanceof ListStyle) {
@@ -244,7 +244,7 @@ export class AutomaticStyles implements IStyles {
     textProperties: ITextProperties
   ): void {
     hash.update('color' + textProperties.getColor());
-    hash.update(textProperties.getFontName() || '');
+    hash.update(textProperties.getFontName() ?? '');
     hash.update(textProperties.getFontSize().toString());
     hash.update(textProperties.getFontVariant());
     hash.update(textProperties.getTextTransformation());

--- a/src/api/office/CommonStyles.ts
+++ b/src/api/office/CommonStyles.ts
@@ -93,9 +93,7 @@ export class CommonStyles implements IStyles {
    * @since 0.9.0
    */
   public getName(displayName: string): string | undefined {
-    const style = this.styles.get(displayName);
-
-    return style !== undefined ? style.getName() : undefined;
+    return this.styles.get(displayName)?.getName();
   }
 
   /** @inheritdoc */

--- a/src/api/text/List.ts
+++ b/src/api/text/List.ts
@@ -43,7 +43,7 @@ export class List extends OdfElement {
    * @since 0.2.0
    */
   public addItem(item?: ListItem): ListItem {
-    const listItem = item || new ListItem();
+    const listItem = item ?? new ListItem();
     this.append(listItem);
 
     return listItem;

--- a/src/api/text/Paragraph.ts
+++ b/src/api/text/Paragraph.ts
@@ -31,7 +31,7 @@ export class Paragraph extends OdfElement {
   public constructor(text?: string) {
     super();
 
-    this.addText(text || '');
+    this.addText(text ?? '');
   }
 
   /**
@@ -97,7 +97,7 @@ export class Paragraph extends OdfElement {
    */
   public setText(text: string): Paragraph {
     this.removeText();
-    this.addText(text || '');
+    this.addText(text ?? '');
 
     return this;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "ES2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "ES2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
**What kind of change is this PR?**

dependency update

**What is the current behavior?**

Code is based on TypeScript version 3.5

**What is the new behavior (if this is a feature change)?**

TypeScript is updated to the latest version (3.9) and the code was adapted to make use of new features.

**Does this PR introduce a breaking change?**

yes; the compile target f the library changed from `ES2015` to `ES2018` which is supported by Node.js 10

**Please check if the PR fulfills these requirements**

- [ ] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
