### PR TITLE
fix(deps): [security] bump xmldom and y18n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8627,9 +8627,9 @@
       "dev": true
     },
     "npm": {
-      "version": "6.14.11",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.11.tgz",
-      "integrity": "sha512-1Zh7LjuIoEhIyjkBflSSGzfjuPQwDlghNloppjruOH5bmj9midT9qcNT0tRUZRR04shU9ekrxNy9+UTBrqeBpQ==",
+      "version": "6.14.12",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.12.tgz",
+      "integrity": "sha512-La0TNNm1TLYaSeOyit+p3xGTRYYRsHae6/RG69MVXurZsWna9jccPP7FOi/u7V9WdiCV5OOojrfMD+WstO5MZQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -12042,7 +12042,7 @@
           "dev": true
         },
         "y18n": {
-          "version": "4.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true
         },
@@ -14857,9 +14857,9 @@
       "dev": true
     },
     "xmldom": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-      "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xtend": {
       "version": "4.0.2",
@@ -14868,9 +14868,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "docs": "rm -r ./dist && tsc && jsdoc2md --name-format --param-list-format list --separators --partial ./tools/jsdoc2md/body.hbs ./tools/jsdoc2md/params-list.hbs ./tools/jsdoc2md/returns.hbs ./tools/jsdoc2md/scope.hbs --files ./dist/api/**/*.js > ./docs/API.md"
   },
   "dependencies": {
-    "xmldom": "^0.4.0"
+    "xmldom": "^0.5.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",


### PR DESCRIPTION
Bumps **xmldom** from 0.4.0 to 0.5.0. This update includes a **security fix**.
Bumps **y18n** from 4.0.0 to 4.0.1. This update includes a **security fix**.

**What kind of change is this PR?**
Security update

**Does this PR introduce a breaking change?**
no
