### PR TITLE
Refactor/move document attributes to document class

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1150,6 +1150,8 @@ This class represents a text document in OpenDocument format.
     * [`.getCommonStyles()`](#TextDocument+getCommonStyles) ⇒ [<code>CommonStyles</code>](#CommonStyles)
     * [`.getFontFaceDeclarations()`](#TextDocument+getFontFaceDeclarations) ⇒ [<code>FontFaceDeclarations</code>](#FontFaceDeclarations)
     * [`.getMeta()`](#TextDocument+getMeta) ⇒ [<code>Meta</code>](#Meta)
+    * [`.getMimeType()`](#TextDocument+getMimeType) ⇒ <code>string</code>
+    * [`.getOfficeVersion()`](#TextDocument+getOfficeVersion) ⇒ <code>string</code>
     * [`.saveFlat(filePath)`](#TextDocument+saveFlat) ⇒ <code>Promise.&lt;void&gt;</code>
     * [`.toString()`](#TextDocument+toString) ⇒ <code>string</code>
 
@@ -1237,6 +1239,40 @@ new TextDocument()
   .setCreator('Homer Simpson');
 ```
 **Since**: 0.6.0  
+
+* * *
+
+<a name="TextDocument+getMimeType"></a>
+
+### `textDocument.getMimeType()` ⇒ <code>string</code>
+The `getMimeType()` method returns the document type of the document.
+
+**Return value**  
+<code>string</code> - The document type of the document
+
+**Example**  
+```js
+new TextDocument()
+  .getMimeType(); // application/vnd.oasis.opendocument.text
+```
+**Since**: 2.1.0  
+
+* * *
+
+<a name="TextDocument+getOfficeVersion"></a>
+
+### `textDocument.getOfficeVersion()` ⇒ <code>string</code>
+The `getOfficeVersion()` method returns the version of the OpenDocument specification to which this document comprises.
+
+**Return value**  
+<code>string</code> - The version of the OpenDocument specification
+
+**Example**  
+```js
+new TextDocument()
+  .getOfficeVersion(); // 1.2
+```
+**Since**: 2.1.0  
 
 * * *
 

--- a/src/api/office/TextBody.ts
+++ b/src/api/office/TextBody.ts
@@ -6,16 +6,29 @@ import { Heading, List, Paragraph } from '../text';
  *
  * @example
  * const body = document.getBody();
- * body.addHeading('My document');
- * body.addParagraph('This is the first paragraph');
- * body.addHeading('Subheadline', 2);
+ * body.addHeading('The Story of My Life');
+ * body.addParagraph('This is the story of a yellow man.');
+ * body.addHeading('The Beginning', 2);
  *
  * @since 0.7.0
  */
 export class TextBody extends OdfElement {
   /**
-   * Adds a heading at the end of the document.
+   * The `addHeading()` method adds a heading at the end of the document.
    * If a text is given, this will be set as text content of the heading.
+   *
+   * @example
+   * // empty 1st level heading
+   * new TextBody()
+   *   .addHeading();
+   *
+   * // 1st level heading with text
+   * new TextBody()
+   *   .addHeading('The Story of My Life');
+   *
+   * // 2nd level heading with text
+   * new TextBody()
+   *   .addHeading('The Beginning', 2);
    *
    * @param {string} [text] The text content of the heading
    * @param {number} [level=1] The heading level; defaults to 1 if omitted
@@ -30,7 +43,7 @@ export class TextBody extends OdfElement {
   }
 
   /**
-   * Adds an empty list at the end of the document.
+   * The `addList()` method adds an empty list at the end of the document.
    *
    * @example
    * new TextBody()
@@ -47,8 +60,17 @@ export class TextBody extends OdfElement {
   }
 
   /**
-   * Adds a paragraph at the end of the document.
+   * The `addParagraph()` method adds a paragraph at the end of the document.
    * If a text is given, this will be set as text content of the paragraph.
+   *
+   * @example
+   * // empty paragraph
+   * new TextBody()
+   *   .addParagraph();
+   *
+   * // paragraph with text
+   * new TextBody()
+   *   .addParagraph('This is the story of a yellow man.');
    *
    * @param {string} [text] The text content of the paragraph
    * @returns {Paragraph} The newly added paragraph

--- a/src/api/office/TextDocument.spec.ts
+++ b/src/api/office/TextDocument.spec.ts
@@ -47,6 +47,18 @@ describe(TextDocument.name, () => {
     });
   });
 
+  describe('mime type', () => {
+    it('return the mime type', () => {
+      expect(document.getMimeType()).toContain('opendocument.text');
+    });
+  });
+
+  describe('office version', () => {
+    it('return version 1.2', () => {
+      expect(document.getOfficeVersion()).toBe('1.2');
+    });
+  });
+
   describe('#saveFlat', () => {
     afterEach(async (done) => {
       const unlinkAsync = promisify(unlink);

--- a/src/api/office/TextDocument.ts
+++ b/src/api/office/TextDocument.ts
@@ -19,8 +19,8 @@ const OFFICE_VERSION = '1.2';
  * document.getMeta().setCreator('Homer Simpson');
  * document.getFontFaceDeclarations().create('FreeSans', 'FreeSans', FontPitch.Variable);
  * document.getCommonStyles().createParagraphStyle('Summary');
- * document.getBody().addHeading('My first document');
- * document.saveFlat('/home/homer/document.fodt');
+ * document.getBody().addHeading('The Story of My Life');
+ * document.saveFlat('/home/homer/my-story.fodt');
  *
  * @since 0.1.0
  */
@@ -51,7 +51,7 @@ export class TextDocument {
    * @example
    * new TextDocument()
    *   .getBody()
-   *   .addHeading('My first document');
+   *   .addHeading('The Story of My Life');
    *
    * @returns {TextBody} A `TextBody` object that holds the content of the document
    * @since 0.7.0
@@ -138,7 +138,7 @@ export class TextDocument {
    *
    * @example
    * new TextDocument()
-   *   .saveFlat('/home/homer/document.fodt');
+   *   .saveFlat('/home/homer/my-story.fodt');
    *
    * @param {string} filePath The file path to write to
    * @returns {Promise<void>}

--- a/src/api/office/TextDocument.ts
+++ b/src/api/office/TextDocument.ts
@@ -8,6 +8,8 @@ import { FontFaceDeclarations } from './FontFaceDeclarations';
 import { TextBody } from './TextBody';
 
 export const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>\n';
+const MIME_TYPE = 'application/vnd.oasis.opendocument.text';
+const OFFICE_VERSION = '1.2';
 
 /**
  * This class represents a text document in OpenDocument format.
@@ -101,6 +103,34 @@ export class TextDocument {
    */
   public getMeta(): Meta {
     return this.meta;
+  }
+
+  /**
+   * The `getMimeType()` method returns the document type of the document.
+   *
+   * @example
+   * new TextDocument()
+   *   .getMimeType(); // application/vnd.oasis.opendocument.text
+   *
+   * @returns {string} The document type of the document
+   * @since 2.1.0
+   */
+  public getMimeType(): string {
+    return MIME_TYPE;
+  }
+
+  /**
+   * The `getOfficeVersion()` method returns the version of the OpenDocument specification to which this document comprises.
+   *
+   * @example
+   * new TextDocument()
+   *   .getOfficeVersion(); // 1.2
+   *
+   * @returns {string} The version of the OpenDocument specification
+   * @since 2.1.0
+   */
+  public getOfficeVersion(): string {
+    return OFFICE_VERSION;
   }
 
   /**

--- a/src/xml/OdfTextElementWriter.ts
+++ b/src/xml/OdfTextElementWriter.ts
@@ -1,7 +1,10 @@
 import { OdfTextElement } from '../api/text';
 import { TextElementName } from './TextElementName';
 
+const CARRIAGE_RETURN = '\r';
+const LINE_FEED = '\n';
 const SPACE = ' ';
+const TAB = '\t';
 
 export class OdfTextElementWriter {
   /**
@@ -33,17 +36,17 @@ export class OdfTextElementWriter {
             index += count;
           }
           break;
-        case '\n':
+        case LINE_FEED:
           this.appendTextNode(document, parent, str);
           this.appendLineBreakNode(document, parent);
           str = '';
           break;
-        case '\t':
+        case TAB:
           this.appendTextNode(document, parent, str);
           this.appendTabNode(document, parent);
           str = '';
           break;
-        case '\r':
+        case CARRIAGE_RETURN:
           break;
         default:
           str += currentChar;

--- a/src/xml/TextDocumentWriter.ts
+++ b/src/xml/TextDocumentWriter.ts
@@ -8,8 +8,6 @@ import { DomVisitor } from './DomVisitor';
 import { OdfAttributeName } from './OdfAttributeName';
 import { OdfElementName } from './OdfElementName';
 
-const OFFICE_VERSION = '1.2';
-
 /**
  * Transforms a {@link TextDocument} object into ODF conform XML
  *
@@ -42,7 +40,7 @@ export class TextDocumentWriter {
     const root = document.firstChild as Element;
 
     this.setXmlNamespaces(root);
-    this.setOfficeAttributes(root);
+    this.setOfficeAttributes(textDocument, root);
 
     const automaticStyles = new AutomaticStyles();
 
@@ -92,15 +90,19 @@ export class TextDocumentWriter {
   /**
    * Sets the mime type and the version attributes.
    *
+   * @param {TextDocument} textDocument The text document to serialize
    * @param {Element} root The root element of the document which will be used as parent
    * @private
    */
-  private setOfficeAttributes(root: Element): void {
+  private setOfficeAttributes(textDocument: TextDocument, root: Element): void {
     root.setAttribute(
       OdfAttributeName.OfficeMimetype,
-      'application/vnd.oasis.opendocument.text'
+      textDocument.getMimeType()
     );
-    root.setAttribute(OdfAttributeName.OfficeVersion, OFFICE_VERSION);
+    root.setAttribute(
+      OdfAttributeName.OfficeVersion,
+      textDocument.getOfficeVersion()
+    );
   }
 
   /**


### PR DESCRIPTION
**What kind of change is this PR?**

Refactoring

**What is the current behavior?**

MIME type and office version are hard coded in the XML writer but these are attributes, that belong to the (text) document and may change.

**What is the new behavior (if this is a feature change)?**

The MIME type and the office version can be requested from the (text) document.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
