### PR TITLE
refactor: no any-typed parameters

### DIFF
--- a/src/api/style/ParagraphProperties.ts
+++ b/src/api/style/ParagraphProperties.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-dupe-class-members */
 import { isNonNegativeNumber, isPercent } from '../util';
 import { Border } from './Border';
 import { BorderStyle } from './BorderStyle';

--- a/src/api/util/isNonNegativeNumber.ts
+++ b/src/api/util/isNonNegativeNumber.ts
@@ -3,11 +3,10 @@
  *
  * ([0-9]+(\.[0-9]*)?|\.[0-9]+)((cm)|(mm)|(in)|(pt)|(pc)|(px))
  *
- * @param {any} value The value that is to be checked
+ * @param {unknown} value The value that is to be checked
  * @returns {boolean} `true` if the given value is a non-negative number, `false` otherwise
  * @private
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isNonNegativeNumber(value: any): boolean {
+export function isNonNegativeNumber(value: unknown): boolean {
   return typeof value === 'number' && value > 0;
 }

--- a/src/api/util/isPercent.ts
+++ b/src/api/util/isPercent.ts
@@ -3,12 +3,11 @@
  *
  * -?([0-9]+(\.[0-9]*)?|\.[0-9]+)%
  *
- * @param {any} value The value that is to be checked
+ * @param {unknown} value The value that is to be checked
  * @returns {boolean} `true` if the given value is a percentage, `false` otherwise
  * @private
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isPercent(value: any): boolean {
+export function isPercent(value: unknown): boolean {
   return (
     typeof value === 'string' && /^-?([0-9]+(\.[0-9]*)?|\.[0-9]+)%$/.test(value)
   );

--- a/src/api/util/isPositiveLength.ts
+++ b/src/api/util/isPositiveLength.ts
@@ -3,11 +3,10 @@
  *
  * ([0-9]*[1-9][0-9]*(\.[0-9]*)?|0+\.[0-9]*[1-9][0-9]*|\.[0-9]*[1-9][0-9]*)((cm)|(mm)|(in)|(pt)|(pc)|(px))
  *
- * @param {any} value The value that is to be checked
+ * @param {unknown} value The value that is to be checked
  * @returns {boolean} `true` if the given value is a positive number, `false` otherwise
  * @private
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isPositiveLength(value: any): boolean {
+export function isPositiveLength(value: unknown): boolean {
   return typeof value === 'number' && value >= 0;
 }


### PR DESCRIPTION
**What kind of change is this PR?**

Refactoring

**What is the current behavior?**

The parameters of the utility functions `isNonNegativeNumber`, `isPercent` and `isPositiveLength` are typed as `any`.

**What is the new behavior (if this is a feature change)?**

Change the parameter type to be `unknown`.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
