### PR TITLE
feat(style): implement text overline

### DIFF
--- a/src/api/office/AutomaticStyles.ts
+++ b/src/api/office/AutomaticStyles.ts
@@ -249,6 +249,16 @@ export class AutomaticStyles implements IStyles {
     hash.update(textProperties.getFontVariant());
     hash.update(textProperties.getTextTransformation());
     hash.update(textProperties.getTypeface().toString());
+
+    const overline = textProperties.getOverline();
+    if (overline) {
+      hash.update('overline-color' + overline.color);
+      hash.update('overline-mode' + overline.mode);
+      hash.update('overline-style' + overline.style);
+      hash.update('overline-type' + overline.type);
+      hash.update('overline-width' + overline.width);
+    }
+
     const underline = textProperties.getUnderline();
     if (underline) {
       hash.update('underline-color' + underline.color);

--- a/src/api/style/ITextProperties.ts
+++ b/src/api/style/ITextProperties.ts
@@ -106,6 +106,27 @@ export interface ITextProperties {
   getFontVariant(): FontVariant;
 
   /**
+   * @since 2.2.0
+   */
+  setOverline(
+    color: 'font-color' | Color,
+    width: LineWidth | number,
+    style: LineStyle,
+    type: LineType,
+    mode: LineMode
+  ): void;
+
+  /**
+   * @since 2.2.0
+   */
+  getOverline(): TextLine | undefined;
+
+  /**
+   * @since 2.2.0
+   */
+  removeOverline(): void;
+
+  /**
    * Sets the transformation that will be applied to the text.
    *
    * @param {TextTransformation} transformation The transformation to apply

--- a/src/api/style/ParagraphStyle.ts
+++ b/src/api/style/ParagraphStyle.ts
@@ -530,6 +530,31 @@ export class ParagraphStyle
   }
 
   /** @inheritDoc */
+  public setOverline(
+    color: 'font-color' | Color,
+    width: LineWidth | number,
+    style: LineStyle,
+    type: LineType,
+    mode: LineMode
+  ): this {
+    this.textProperties.setOverline(color, width, style, type, mode);
+
+    return this;
+  }
+
+  /** @inheritDoc */
+  public getOverline(): TextLine | undefined {
+    return this.textProperties.getOverline();
+  }
+
+  /** @inheritDoc */
+  public removeOverline(): this {
+    this.textProperties.removeOverline();
+
+    return this;
+  }
+
+  /** @inheritDoc */
   public getTextTransformation(): TextTransformation {
     return this.textProperties.getTextTransformation();
   }

--- a/src/api/style/TextProperties.spec.ts
+++ b/src/api/style/TextProperties.spec.ts
@@ -94,6 +94,91 @@ describe(TextProperties.name, () => {
     });
   });
 
+  describe('overline', () => {
+    const testLineColor = Color.fromRgb(1, 2, 3);
+    const testLineMode = LineMode.SkipWhiteSpace;
+    const testLineStyle = LineStyle.Wave;
+    const testLineType = LineType.Double;
+    const testLineWidth = 13.37;
+    const expectedLine: Readonly<TextLine> = {
+      color: testLineColor,
+      mode: testLineMode,
+      style: testLineStyle,
+      type: testLineType,
+      width: testLineWidth,
+    };
+
+    it('return undefined by default', () => {
+      // Assert
+      expect(properties.getOverline()).toBeUndefined();
+    });
+
+    it('return line with defaults if no parameters are passed', () => {
+      // Arrange
+      const expectedDefaultLine: TextLine = {
+        color: 'font-color',
+        mode: LineMode.Continuous,
+        style: LineStyle.Solid,
+        type: LineType.Single,
+        width: LineWidth.Auto,
+      };
+
+      // Act
+      properties.setOverline();
+
+      // Assert
+      expect(properties.getOverline()).toEqual(expectedDefaultLine);
+    });
+
+    it('return previously set line', () => {
+      // Act
+      properties.setOverline(
+        testLineColor,
+        testLineWidth,
+        testLineStyle,
+        testLineType,
+        testLineMode
+      );
+
+      // Assert
+      expect(properties.getOverline()).toEqual(expectedLine);
+    });
+
+    it('ignore invalid value', () => {
+      // Arrange
+      properties.setOverline(
+        testLineColor,
+        testLineWidth,
+        testLineStyle,
+        testLineType,
+        testLineMode
+      );
+
+      // Act
+      properties.setOverline(testLineColor, -0.1);
+
+      // Assert
+      expect(properties.getOverline()).toEqual(expectedLine);
+    });
+
+    it('remove previously set border', () => {
+      // Arrange
+      properties.setOverline(
+        testLineColor,
+        testLineWidth,
+        testLineStyle,
+        testLineType,
+        testLineMode
+      );
+
+      // Act
+      properties.removeOverline();
+
+      // Assert
+      expect(properties.getOverline()).toBeUndefined();
+    });
+  });
+
   describe('text transformation', () => {
     it('return `None` by default', () => {
       expect(properties.getTextTransformation()).toBe(TextTransformation.None);

--- a/src/api/style/TextProperties.ts
+++ b/src/api/style/TextProperties.ts
@@ -24,7 +24,7 @@ export class TextProperties implements ITextProperties {
   private fontSize: number;
   private fontVariant: FontVariant;
   // private lineThrough: TextLine | undefined;
-  // private overline: TextLine | undefined;
+  private overline: TextLine | undefined;
   private transformation: TextTransformation;
   private typeface: Typeface;
   private underline: TextLine | undefined;
@@ -91,6 +91,35 @@ export class TextProperties implements ITextProperties {
   /** @inheritDoc */
   public getFontVariant(): FontVariant {
     return this.fontVariant;
+  }
+
+  /** @inheritDoc */
+  public setOverline(
+    color: 'font-color' | Color = 'font-color',
+    width: LineWidth | number = LineWidth.Auto,
+    style: LineStyle = LineStyle.Solid,
+    type: LineType = LineType.Single,
+    mode: LineMode = LineMode.Continuous
+  ): void {
+    if (typeof width !== 'number' || isPositiveLength(width)) {
+      this.overline = {
+        color,
+        mode,
+        style,
+        type,
+        width,
+      };
+    }
+  }
+
+  /** @inheritDoc */
+  public getOverline(): TextLine | undefined {
+    return this.overline;
+  }
+
+  /** @inheritDoc */
+  public removeOverline(): void {
+    this.overline = undefined;
   }
 
   /** @inheritDoc */

--- a/src/xml/office/StylesWriter.spec.ts
+++ b/src/xml/office/StylesWriter.spec.ts
@@ -19,6 +19,7 @@ import {
   LineStyle,
   LineType,
   LineMode,
+  LineWidth,
 } from '../../api/style';
 import { OdfElementName } from '../OdfElementName';
 import { StylesWriter } from './StylesWriter';
@@ -851,6 +852,25 @@ describe(StylesWriter.name, () => {
 
       expect(documentAsString).toMatch(
         /<style:text-properties fo:font-style="oblique" fo:font-weight="bold"\/>/
+      );
+    });
+
+    it('set overline', () => {
+      testStyle.setOverline(
+        'font-color',
+        LineWidth.Bold,
+        LineStyle.LongDash,
+        LineType.Single,
+        LineMode.Continuous
+      );
+
+      stylesWriter.write(commonStyles, testDocument, testRoot);
+      const documentAsString = new XMLSerializer().serializeToString(
+        testDocument
+      );
+
+      expect(documentAsString).toMatch(
+        /<style:text-properties style:text-overline-type="single" style:text-overline-style="long-dash" style:text-overline-width="bold" style:text-overline-color="font-color" style:text-overline-mode="continuous"\/>/
       );
     });
 

--- a/src/xml/office/TextPropertiesVisitor.ts
+++ b/src/xml/office/TextPropertiesVisitor.ts
@@ -106,6 +106,38 @@ export class TextPropertiesVisitor {
       );
     }
 
+    const overline = textProperties.getOverline();
+    if (overline) {
+      textPropertiesElement.setAttribute(
+        'style:text-overline-type',
+        overline.type
+      );
+
+      textPropertiesElement.setAttribute(
+        'style:text-overline-style',
+        overline.style
+      );
+
+      textPropertiesElement.setAttribute(
+        'style:text-overline-width',
+        typeof overline.width === 'number'
+          ? `${overline.width}pt`
+          : overline.width
+      );
+
+      textPropertiesElement.setAttribute(
+        'style:text-overline-color',
+        overline.color === 'font-color'
+          ? overline.color
+          : overline.color.toHex()
+      );
+
+      textPropertiesElement.setAttribute(
+        'style:text-overline-mode',
+        overline.mode
+      );
+    }
+
     if (
       typeface === Typeface.Bold ||
       typeface === Typeface.BoldItalic ||

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -308,6 +308,20 @@ xdescribe('integration', () => {
       paragraph.setStyle(style);
     });
 
+    it('overline', () => {
+      const style = new ParagraphStyle();
+      style.setOverline(
+        Color.fromRgb(62, 180, 137),
+        LineWidth.Bold,
+        LineStyle.Wave,
+        LineType.Single,
+        LineMode.Continuous
+      );
+
+      const paragraph = body.addParagraph('Some overlined text');
+      paragraph.setStyle(style);
+    });
+
     it('text transformation', () => {
       const style = new ParagraphStyle();
       style.setTextTransformation(TextTransformation.Uppercase);


### PR DESCRIPTION
**What kind of change is this PR?**

Feature

**What is the current behavior?**

Text cannot be styled to show an overlining.

**What is the new behavior (if this is a feature change)?**

Text can be styled to show an overlining including the line style as well as its color and width.
Note: not all combinations are supported by readers like LibreOffice.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**

- [x] Fix/Feature: JSDocs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
